### PR TITLE
fix(audio): eliminate sort drag flicker on audio settings page

### DIFF
--- a/lib/providers/audio_settings_provider.dart
+++ b/lib/providers/audio_settings_provider.dart
@@ -147,30 +147,48 @@ class AudioSettingsNotifier extends StateNotifier<AudioSettingsState> {
   Future<void> setFormatPriority(List<AudioFormat> priority) async {
     if (_settings == null) return;
 
-    await _settingsRepository
-        .update((s) => s.audioFormatPriorityList = priority);
-    _settings!.audioFormatPriorityList = priority;
+    final previous = state.formatPriority;
     state = state.copyWith(formatPriority: priority);
+
+    try {
+      await _settingsRepository
+          .update((s) => s.audioFormatPriorityList = priority);
+      _settings!.audioFormatPriorityList = priority;
+    } catch (_) {
+      state = state.copyWith(formatPriority: previous);
+    }
   }
 
   /// 设置 YouTube 流优先级
   Future<void> setYoutubeStreamPriority(List<StreamType> priority) async {
     if (_settings == null) return;
 
-    await _settingsRepository
-        .update((s) => s.youtubeStreamPriorityList = priority);
-    _settings!.youtubeStreamPriorityList = priority;
+    final previous = state.youtubeStreamPriority;
     state = state.copyWith(youtubeStreamPriority: priority);
+
+    try {
+      await _settingsRepository
+          .update((s) => s.youtubeStreamPriorityList = priority);
+      _settings!.youtubeStreamPriorityList = priority;
+    } catch (_) {
+      state = state.copyWith(youtubeStreamPriority: previous);
+    }
   }
 
   /// 设置 Bilibili 流优先级
   Future<void> setBilibiliStreamPriority(List<StreamType> priority) async {
     if (_settings == null) return;
 
-    await _settingsRepository
-        .update((s) => s.bilibiliStreamPriorityList = priority);
-    _settings!.bilibiliStreamPriorityList = priority;
+    final previous = state.bilibiliStreamPriority;
     state = state.copyWith(bilibiliStreamPriority: priority);
+
+    try {
+      await _settingsRepository
+          .update((s) => s.bilibiliStreamPriorityList = priority);
+      _settings!.bilibiliStreamPriorityList = priority;
+    } catch (_) {
+      state = state.copyWith(bilibiliStreamPriority: previous);
+    }
   }
 
   /// 设置自动匹配歌词


### PR DESCRIPTION
## Summary
- Fixed a visual flicker where dragging to reorder items on the audio settings page would briefly flash the old order before showing the new one
- Applied optimistic state updates to `setFormatPriority`, `setYoutubeStreamPriority`, and `setBilibiliStreamPriority` — same pattern already used by the radio page

## Root cause
The provider methods were doing `await` (async DB write) **before** updating state. `ReorderableListView` completes its drag animation immediately, but state hadn't changed yet, so the next widget rebuild showed the old order first.

## Fix
Update state synchronously first, then persist to DB async, rolling back on failure. This matches the pattern:

| Page | Instant feedback mechanism |
|---|---|
| Queue | Widget `_localQueue` |
| Radio | Controller optimistic update |
| Library | Widget `_localPlaylists` |
| Audio Settings | Provider optimistic update **(this PR)** |
| Lyrics Source | Widget `_sourceOrder` |

Each page uses the approach best suited to its needs — different mechanisms, same principle (sync UI update → async persist).

## Test plan
- [ ] Manual: Drag reorder format priority (Opus/AAC) on audio settings page — no flicker
- [ ] Manual: Drag reorder YouTube stream priority — no flicker
- [ ] Manual: Drag reorder Bilibili stream priority — no flicker
- [ ] Verify existing tests pass: `dart test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)