### PR TITLE
test: replace fixed pump counts with condition waits

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -140,6 +140,12 @@ Never:
 - Do not open or migrate the Isar database through ad-hoc paths.
 - Do not add hidden global enabled-source filters for search.
 - Do not use direct `Image.network()` / `Image.file()` in UI.
+- Do not call `pumpEventQueue` in tests. A pump count buys event loop turns,
+  not progress, so it fails under load in one direction and on an idle machine
+  in the other (issues #43, #55). Use `pumpUntil` from
+  `test/support/pump_until.dart` to wait for a condition that is false on entry,
+  or `drainEventQueue` when asserting that something did *not* happen.
+  `test/support/wait_convention_static_rule_test.dart` enforces this.
 - Do not try to "fix" the benign `Failed to update ui::AXTree` Windows log spam —
   it is a known Flutter engine bug (`flutter/flutter#182444`), not an FMP defect.
   See `docs/troubleshooting.md`.

--- a/docs/review/05-roadmap.md
+++ b/docs/review/05-roadmap.md
@@ -1000,7 +1000,7 @@ Phase 1 修好預取之後（結果寫回佇列實例而不是被丟棄的 `copy
 | **#40** | Windows SMTC 兩個無法作用的控制項 | **保留，標題要改成四個** | **next/prev → Phase 4B；seek/shuffle/repeat → Phase 0（改成不宣告）** | 實際是 **next / previous（電台時）、seek、shuffle、repeat** 四項，而且分兩類：next/prev **事件有到 FMP**（有 log），是 FMP 自己的 config 沒跟著關 —— 可修；seek/shuffle/repeat **事件沒到**，是 `smtc_windows` 1.1.0 的 Dart wrapper 沒 export —— 只能改成「不要對外宣稱有」。另外 issue 對症狀二的機制推論被推翻：`IsPlaybackPositionEnabled` 本來就是 `False`，Windows 根本不會畫可拖曳的條 |
 | **#41** | 音訊輸出裝置失效被誤判成「播放失敗」 | **✅ 已修（`056f20c3`），驗證後關閉** | **QW-11** | `OutputDeviceFailed`（`audio_types.dart:107`）就是 issue 要的型別化訊號，`_isStringMediaOpenError` 已全庫零命中。關閉前建議複驗一次「電台路徑不再吞掉錯誤」（`RadioController` 過去完全沒訂閱 `errorStream`） |
 | **#42** | `preferredAudioDevice*` 是死欄位 | **保留，但第二條指控要撤下** | **Phase 3c** | 第一條（功能缺口）證實。第二條（「備份仍照樣匯出匯入」）**推翻**，三層互相獨立的反證：`backup_data.dart` 裡根本沒有這兩個欄位；`backup_service.dart:765-769` 賦值來源是本機值且上一行註解寫著「保留当前值」；被引為證據的測試名字就是 `preserves device-specific ones`。**備份層的處理反而是對的。** 那條指控放在 `RadioStation.note` 上才成立 |
-| **#43** | `audio_controller_phase1_test` 在負載下偶發失敗 | **保留，但改寫成「測試 fixture 生命週期洩漏」** | **Phase 0a + Phase 3** | 根因推測是錯的：CI 實際失敗的那條測試**已經在用** issue 建議的條件式 helper，而它自己也有 `maxPumps = 50` 上限。真正的鏈是 `tearDown` 沒有 drain 進行中的非同步工作就 `isar.close()` → `IsarError: Isar instance has already been closed` → 狀態永遠不收斂。修法方向要改（tearDown 前 await/取消 in-flight persistence，或讓 `QueueRepository` 在 Isar 已關閉時安全 no-op）。**順帶：生產環境的 `queue_manager.dart:402` 有同類風險，值得單開 issue** |
+| **#43** | `audio_controller_phase1_test` 在負載下偶發失敗 | **保留，但改寫成「測試 fixture 生命週期洩漏」** | **Phase 0a + Phase 3** | 根因推測是錯的：CI 實際失敗的那條測試**已經在用** issue 建議的條件式 helper，而它自己也有 `maxPumps = 50` 上限。真正的鏈是 `tearDown` 沒有 drain 進行中的非同步工作就 `isar.close()` → `IsarError: Isar instance has already been closed` → 狀態永遠不收斂。修法方向要改（tearDown 前 await/取消 in-flight persistence，或讓 `QueueRepository` 在 Isar 已關閉時安全 no-op）。**順帶：生產環境的 `queue_manager.dart:402` 有同類風險，值得單開 issue**。**2026-09-08 再更正：這一格與原 issue 的推測都只對一半，而且兩邊都低估了範圍 —— 根因不是某一條測試，是「固定圈數的 `pumpEventQueue`」這個形狀，全庫 194 處。見 §6.15** |
 | **#44** | 遷移 isar 至 isar_community | **保留，補兩段** | **Phase 2** | ① **遷移步驟不完整 —— 照著做會在 `flutter pub get` 就失敗**，缺 slang 3.32→4.19 這個連動的大版本升級（實測輸出見 03 §14.2）② **價值被低估**：`isar_generator` 的 `analyzer >=4.6.0 <6.0.0` 把整個 build 生態釘在 2023 年，而且它是 Riverpod 3 的**硬**阻塞。這讓 #44 從「非緊急的維護性改善」升格為「其他兩件事的前置條件」③ 資料遷移成本**實測**為零（不只是 changelog 背書） |
 
 ### 建議新開的 issue（目前沒有 issue 在追，但都是 P0/P1）
@@ -2486,3 +2486,147 @@ Windows 帳號名。repo 是公開的，已遮成 `<user>`（`a9f32737`）。憑
 **沒有任何一份 AGENTS.md 說過該用哪個**。規則是「改到的行才轉，不做全庫轉換」：
 全庫轉換會產生一個橫跨 199 檔、把任何真實變更都淹掉的 diff，而混用的代價是
 可讀性不是正確性。數字放這裡，規則放 AGENTS.md，不互相重複。
+
+---
+
+### 6.15 執行時的失效重核（2026-09-08，issue #43 / #55：固定圈數的 `pumpEventQueue`）
+
+觸發點是 CI 而不是計畫：2026-09-07 一天內 CI 紅了 7 次，**其中 4 次是同一個檔案
+的同一種毛病**，包含 `main` 上的一次（run `34120654888`，12:12–12:42 main 是紅的）。
+另外兩次是 dependabot PR（go_router 18、package_info_plus 9）—— **那兩次的紅跟
+升級毫無關係**，也是同一條抖動。也就是說這條抖動當時正在讓 CI 結果無法解讀。
+
+#### 根因不是某一條測試，是一個形狀
+
+```dart
+await pumpEventQueue(times: 10);   // 等 10 圈事件迴圈
+expect(toasts, isNotEmpty);        // 立刻斷言
+```
+
+`pumpEventQueue` 的實作（`test_api-0.7.13/lib/src/scaffolding/utils.dart:16`）只是
+遞迴排零延遲的 `Timer`：
+
+```dart
+Future pumpEventQueue({int times = 20}) {
+  if (times == 0) return Future.value();
+  return Future(() => pumpEventQueue(times: times - 1));
+}
+```
+
+**圈數換不到「進度」。** 背景 I/O、Isar 交易與真計時器什麼時候完成跟圈數無關。
+機器滿載時同樣的圈數換到的進度更少（正向斷言掛掉，#43）；反過來，同樣的圈數耗掉
+的牆鐘時間更多，「還沒發生」提早變成「已經發生」（反向斷言掛掉，#55）。
+**兩個方向壞在相反的地方 —— 所以把圈數調大不是修，只是把競態換一邊。**
+
+#### 三條要更正的說法
+
+| # | 之前說 | 實況 |
+|---|---|---|
+| 1 | issue #43 的修法範圍是「同檔案所有 `pumpEventQueue(times: N)` 之後緊接斷言的地方」 | **不夠。** 本輪的基準壓力跑抓到第三條失敗，是 `prepareCurrentTrack prefetch` 那條：它的 pump 之後隔了幾行才斷言，按「緊接斷言」的規則會被判定為安全並留下來 |
+| 2 | 只有 `pumpEventQueue(times: N)` 有問題 | 不帶參數的 `pumpEventQueue()` 就是 `times: 20`，同一個病。全庫另有 **27 處**，其中 19 處下一行就是 `expect(` |
+| 3 | 「條件式等待」就是把固定圈數換成 `while (!condition)` | **輪詢的方式本身是承重的**，見下 |
+
+#### 輪詢方式是承重的，這是量出來的不是選出來的
+
+套件裡既有的區域 helper 自發收斂出兩種形狀，本輪先照抄了「睡 10ms」那一種，
+結果連續踩到兩件事：
+
+- **睡著取樣會整段錯過瞬間狀態，而且睡覺本身會改變被測程式的行為** —— 真計時器
+  因此提早到期。`audio_controller_phase1_test` 的 `superseded source error` 那條
+  在 10ms 輪詢下**永遠**等不到它要的狀態，而 5 圈 `pumpEventQueue` 等得到。
+- **改成一圈一檢查（`pumpEventQueue(times: 1)`）又太細**：等待在更早的時點返回，
+  呼叫端的下一步就落在不同的交錯上，同一條測試直接卡死（`resolves` 停在 2，
+  狀態永遠不換手）。
+
+最後的形狀是：前 50 輪用完整的 `pumpEventQueue()`（20 圈，**不耗牆鐘時間**），
+之後改成睡 10ms。20 圈這個粒度不是挑的，是套件裡既有 helper 一直在用的。
+
+#### 還有一個陷阱：條件在進入時就成立 = 一圈都沒推
+
+`pumpUntil` 一進來就檢查條件，成立就返回。**如果條件在進入時已經成立，它會立刻
+返回、一圈都沒推 —— 比它取代掉的固定圈數推進得更少。** 本輪有兩條測試因此變紅：
+
+- `temporary restore replaces the queue copy`：條件寫成 `queueTrack.sourceId ==
+  'restore-b'`，但那個 sourceId 從頭到尾都是 `restore-b`；真正會變的是佇列換上的
+  **新實例**，所以條件要寫 `!identical(queueTrack, queueTrackBeforeTemporary)`。
+- `superseded source error`：條件漏掉了最後才收斂的那一項。
+
+規則因此寫進 `pumpUntil` 的文檔註釋：**條件必須是「進入時還不成立」的東西。**
+
+#### 做了什麼
+
+| 項目 | 數字 |
+|---|---|
+| `pumpEventQueue` 呼叫點移除 | **194**（167 個 `times: N` + 27 個不帶參數） |
+| 換成 `pumpUntil`（條件式等待） | 182 處 |
+| 換成 `drainEventQueue`（斷言缺席） | 58 處 |
+| 收斂掉的區域 wait helper | 10 份 |
+| 收斂掉的 `_CountWaiter` | 3 份 → `test/support/fakes/count_waiters.dart` |
+| 動到的檔案 | 33 |
+
+`drainEventQueue` 是刻意留的出口，不是妥協：「某件事不該發生」的斷言等不到任何
+條件（條件在第 0 圈就成立）。首選是先用 `pumpUntil` 等一個**排在它之後**的里程碑
+再斷言缺席；找不到里程碑時才用它，而 `reason` 讓 `rg drainEventQueue` 一次列出
+全部「我們知道自己在斷言缺席」的地方 —— 註解做不到這件事。
+
+順帶修掉一個既有缺陷：`mix_session_coordinator_test` 的區域 `_waitFor` **逾時後
+靜靜返回**，不 `fail`。逾時會偽裝成後面那條斷言的失敗。
+
+#### #55：把一條會競態的測試拆成兩條不會競態的
+
+`playback_handoff_gate_test` 用固定 10 圈去斷言「seek 還沒送出」，對上 40ms 的真
+計時器。**沒有用 `fakeAsync`** —— `PlaybackHandoffGate` 同時用
+`Future.delayed`（`:209`）與 `DateTime.now()`（`:272`），`fakeAsync` 管不到後者，
+要先把生產程式碼改成 `clock.now()`；為一條測試改生產程式碼的時鐘來源不成比例。
+改成：一條用 30 秒的視窗（長到任何 pump 預算都追不上）驗「視窗內延後」，另一條用
+短視窗加 `pumpUntil` 驗「視窗過後送出」。原本一條測試同時守這兩件事，正是它會
+抖的原因。
+
+> **第二條的第一版是錯的，而且是壓力跑抓到的。** 短視窗一開始寫成 1ms ——
+> 那是同一種競態換了個方向：視窗可能在下一行的 `deferSeek` 被呼叫**之前**就關掉，
+> `deferSeek` 回 `null`，`!` 直接炸。改動後的 20 次壓力跑抓到 1 次。改成 500ms：
+> 這個數字不是「夠快」而是「夠慢」，需要的只是「視窗在下一行還開著」，500ms 對
+> 相鄰兩行語句是四個數量級的餘裕。**這件事本身就是這一輪的論點** —— 任何拿牆鐘
+> 時間當同步點的斷言都要問「餘裕有幾個數量級」，而不是「這樣應該夠吧」。
+
+#### 守門
+
+`test/support/wait_convention_static_rule_test.dart` 照
+`isar_boundary_static_rule_test.dart` 的既有形狀：掃 `test/` 全部 `.dart`、
+`expect(scanned, greaterThan(200))` 防掃空、外加「餵它合成違規要抓得到」與
+「註解裡提到 API 不算違規」兩條自我測試。
+
+規則是**完全禁止**呼叫 `pumpEventQueue`，不是只禁「pump 之後緊接斷言」——
+上面第 1 條更正就是理由：本輪第三條抖動的斷言隔了幾行，窄規則抓不到。
+豁免只有三個檔案：`pump_until.dart`（包裝它的那一層）、它自己的測試（需要原始的
+固定圈數當對照），以及守門測試自己（合成樣本存在字串常量裡）。
+
+#### 驗收
+
+| 項目 | 結果 |
+|---|---|
+| 完整套件 | **1505 passed**（基準 1495；+5 `pump_until_test`、+4 守門測試、+1 #55 拆出來的那條） |
+| `flutter analyze` | 乾淨 |
+| `dart format lib test` | 577 檔 0 diff |
+| 壓力跑（改動前） | **20 次 2 紅** —— 兩次都是 `prepareCurrentTrack prefetch` 那條 |
+| 壓力跑（改動後） | **25 次 0 紅** |
+
+壓力跑的方法：把 shell 的 `ProcessorAffinity` 限成 4 核（GitHub public repo runner
+的規格），子行程繼承，跑
+`audio_controller_phase1_test.dart` + `playback_handoff_gate_test.dart`。
+兩組都跑在 `git worktree` 的獨立副本上，同一台機器、同樣負載。
+
+三件據實記錄的事：
+
+1. **改動後的第一輪 20 次有 1 紅，而且是本輪自己種下的** —— 上面 #55 那則引文說的
+   1ms 視窗。修掉之後補跑，19 + 6 = **25 次 0 紅**。
+2. 那 20 次裡另有 1 次在 **1 秒內**失敗、完全沒有測試輸出 —— 行程根本沒起來（當時
+   主工作樹正在跑完整套件，推測是共用快取的競用）。那不是測試失敗，沒有計入
+   25 次，也沒有計成紅。
+3. 兩組的跑次都不是實驗室等級的控制：跑的期間這台機器上還有別的工作。這個方向
+   對「改動後」是不利的，不是有利的。
+
+> **這證明不了「已經沒有抖動」。** 既有基準是 24 次 1 紅，要證到 0 需要 70 次以上。
+> 這裡證的是：已知的機制被移除了，而且改動前的失敗在改動後不再出現。
+
+**不需要實機驗證** —— 純測試改動，沒有任何 user-visible 行為變更。

--- a/test/data/sources/bilibili_live_client_test.dart
+++ b/test/data/sources/bilibili_live_client_test.dart
@@ -6,6 +6,7 @@ import 'package:fmp/data/models/live_room.dart';
 import 'package:fmp/data/sources/bilibili_exception.dart';
 import 'package:fmp/data/sources/bilibili_live_client.dart';
 import 'package:fmp/data/sources/source_http_policy.dart';
+import '../../support/pump_until.dart';
 
 void main() {
   group('parseLiveUrl', () {
@@ -791,7 +792,10 @@ void main() {
 
       final search = client.searchRooms('music');
       await liveRoomRequestStarted.future;
-      await pumpEventQueue(times: 5);
+      await pumpUntil(
+        () => biliUserRequestStarted.isCompleted,
+        reason: 'the two lookups should be issued in parallel',
+      );
 
       expect(biliUserRequestStarted.isCompleted, isTrue);
 
@@ -1186,7 +1190,10 @@ void main() {
         cookie: 'SESSDATA=abc',
       );
       await firstRoomLookupStarted.future;
-      await pumpEventQueue(times: 5);
+      await pumpUntil(
+        () => secondRoomLookupStarted.isCompleted,
+        reason: 'the two room lookups should be issued in parallel',
+      );
 
       expect(secondRoomLookupStarted.isCompleted, isTrue);
 

--- a/test/data/sources/bilibili_live_client_test.dart
+++ b/test/data/sources/bilibili_live_client_test.dart
@@ -6,6 +6,7 @@ import 'package:fmp/data/models/live_room.dart';
 import 'package:fmp/data/sources/bilibili_exception.dart';
 import 'package:fmp/data/sources/bilibili_live_client.dart';
 import 'package:fmp/data/sources/source_http_policy.dart';
+
 import '../../support/pump_until.dart';
 
 void main() {

--- a/test/providers/download/file_exists_cache_phase4_test.dart
+++ b/test/providers/download/file_exists_cache_phase4_test.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:fmp/providers/download/file_exists_cache.dart';
+import '../../support/pump_until.dart';
 
 Future<void> _waitForCondition(bool Function() condition) async {
   final stopwatch = Stopwatch()..start();
@@ -380,7 +381,9 @@ void main() {
 
         expect(cache.exists(path), isFalse);
         container.dispose();
-        await pumpEventQueue(times: 5);
+        await drainEventQueue(
+          reason: 'a disposed cache must not bump its epoch',
+        );
 
         expect(cache.cacheEpoch, 0);
       },
@@ -406,7 +409,9 @@ void main() {
         expect(cache.getFirstExisting([path]), isNull);
         expect(cache.pendingRefreshCount, 1);
         container.dispose();
-        await pumpEventQueue(times: 5);
+        await drainEventQueue(
+          reason: 'a disposed cache must drop its pending refreshes',
+        );
 
         expect(cache.cacheEpoch, 0);
         expect(cache.pendingRefreshCount, 0);

--- a/test/providers/download/file_exists_cache_phase4_test.dart
+++ b/test/providers/download/file_exists_cache_phase4_test.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:fmp/providers/download/file_exists_cache.dart';
+
 import '../../support/pump_until.dart';
 
 void main() {

--- a/test/providers/download/file_exists_cache_phase4_test.dart
+++ b/test/providers/download/file_exists_cache_phase4_test.dart
@@ -5,16 +5,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:fmp/providers/download/file_exists_cache.dart';
 import '../../support/pump_until.dart';
 
-Future<void> _waitForCondition(bool Function() condition) async {
-  final stopwatch = Stopwatch()..start();
-  while (!condition()) {
-    if (stopwatch.elapsed > const Duration(seconds: 2)) {
-      fail('Timed out waiting for condition.');
-    }
-    await Future<void>.delayed(const Duration(milliseconds: 10));
-  }
-}
-
 void main() {
   group('Phase 4 Task 3 file exists cache', () {
     test(
@@ -209,14 +199,16 @@ void main() {
         final cache = container.read(fileExistsCacheProvider.notifier);
 
         expect(cache.exists(existsPath), isFalse);
-        await _waitForCondition(
+        await pumpUntil(
           () => container.read(filePathExistsProvider(existsPath)),
+          reason: 'the first probe should settle to exists',
         );
         expect(values, [0, 1]);
 
         expect(cache.getFirstExisting([refreshPath]), isNull);
-        await _waitForCondition(
+        await pumpUntil(
           () => container.read(filePathExistsProvider(refreshPath)),
+          reason: 'the refreshed probe should settle to exists',
         );
         expect(values, [0, 1, 2]);
 
@@ -325,7 +317,10 @@ void main() {
         final missingPath = '${tempDir.path}/missing_cover.jpg';
 
         expect(cache.exists(missingPath), isFalse);
-        await _waitForCondition(() => cache.debugMissingPathCount == 1);
+        await pumpUntil(
+          () => cache.debugMissingPathCount == 1,
+          reason: 'the missing path should be recorded',
+        );
 
         expect(cache.getFirstExisting([missingPath]), isNull);
         expect(cache.pendingRefreshCount, 0);

--- a/test/providers/import_playlist_provider_phase2_test.dart
+++ b/test/providers/import_playlist_provider_phase2_test.dart
@@ -12,6 +12,7 @@ import 'package:fmp/services/import/import_service.dart';
 import 'package:fmp/services/import/playlist_import_service.dart'
     as legacy_import;
 import 'package:riverpod/riverpod.dart';
+import '../support/pump_until.dart';
 
 void main() {
   group('PlaylistImportState.selectedTracks', () {
@@ -64,11 +65,17 @@ void main() {
 
         final oldImport = service.enqueueImport(_playlistImportResult('old'));
         final oldFuture = notifier.importAndMatch('https://example.com/old');
-        await pumpEventQueue(times: 2);
+        await pumpUntil(
+          () => service.importCallCount == 1,
+          reason: 'the old import should be in flight',
+        );
 
         final newImport = service.enqueueImport(_playlistImportResult('new'));
         final newFuture = notifier.importAndMatch('https://example.com/new');
-        await pumpEventQueue(times: 2);
+        await pumpUntil(
+          () => service.importCallCount == 2,
+          reason: 'the newer import should supersede the old one',
+        );
 
         oldImport.complete();
         await oldFuture;
@@ -105,11 +112,17 @@ void main() {
 
         final oldSearch = service.enqueueSearch([_track('old-manual')]);
         final oldFuture = notifier.manualSearch(0, 'old query');
-        await pumpEventQueue(times: 2);
+        await pumpUntil(
+          () => service.searchCallCount == 1,
+          reason: 'the old manual search should be in flight',
+        );
 
         final newSearch = service.enqueueSearch([_track('new-manual')]);
         final newFuture = notifier.manualSearch(0, 'new query');
-        await pumpEventQueue(times: 2);
+        await pumpUntil(
+          () => service.searchCallCount == 2,
+          reason: 'the newer manual search should supersede the old one',
+        );
 
         oldSearch.complete();
         await oldFuture;
@@ -416,6 +429,10 @@ class _FakePlaylistImportService extends legacy_import.PlaylistImportService {
   final List<_PendingPlaylistImport> _pendingImports = [];
   final List<_PendingManualSearch> _pendingSearches = [];
 
+  /// 已經被呼叫幾次。單調遞增，所以 `pumpUntil` 等得到「請求真的送出去了」。
+  int importCallCount = 0;
+  int searchCallCount = 0;
+
   @override
   Stream<legacy_import.ImportProgress> get progressStream =>
       _progressController.stream;
@@ -439,6 +456,7 @@ class _FakePlaylistImportService extends legacy_import.PlaylistImportService {
         legacy_import.SearchSourceConfig.all,
     int maxSearchResults = 5,
   }) async {
+    importCallCount++;
     final pending = _pendingImports.removeAt(0);
     await pending.gate.future;
     return pending.result;
@@ -451,6 +469,7 @@ class _FakePlaylistImportService extends legacy_import.PlaylistImportService {
         legacy_import.SearchSourceConfig.all,
     int maxResults = 5,
   }) async {
+    searchCallCount++;
     final pending = _pendingSearches.removeAt(0);
     await pending.gate.future;
     return pending.results;

--- a/test/providers/import_playlist_provider_phase2_test.dart
+++ b/test/providers/import_playlist_provider_phase2_test.dart
@@ -12,6 +12,7 @@ import 'package:fmp/services/import/import_service.dart';
 import 'package:fmp/services/import/playlist_import_service.dart'
     as legacy_import;
 import 'package:riverpod/riverpod.dart';
+
 import '../support/pump_until.dart';
 
 void main() {

--- a/test/providers/playlist_provider_phase2_test.dart
+++ b/test/providers/playlist_provider_phase2_test.dart
@@ -11,6 +11,7 @@ import 'package:fmp/providers/library/library_invalidation_coordinator.dart';
 import 'package:fmp/providers/library/playlist_provider.dart';
 import 'package:isar_community/isar.dart';
 import '../support/isar_test_harness.dart';
+import '../support/pump_until.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -35,7 +36,7 @@ void main() {
         expect(createdPlaylist, isNotNull);
         final playlist = createdPlaylist!;
 
-        await harness.pumpUntil(
+        await pumpUntil(
           () =>
               harness.container.read(playlistListProvider).playlists.length ==
               1,
@@ -52,7 +53,7 @@ void main() {
               _buildTrack(sourceId: 'watch-track', title: 'Watch Track'),
             ]);
 
-        await harness.pumpUntil(
+        await pumpUntil(
           () =>
               harness.container
                   .read(playlistListProvider)
@@ -98,7 +99,7 @@ void main() {
               _buildTrack(sourceId: 'duplicate-track', title: 'Original Track'),
             );
 
-        await harness.pumpUntil(
+        await pumpUntil(
           () {
             final detail = harness.container.read(
               playlistDetailProvider(playlist.id),
@@ -143,7 +144,7 @@ void main() {
       expect(createdPlaylist, isNotNull);
       final playlist = createdPlaylist!;
 
-      await harness.pumpUntil(() {
+      await pumpUntil(() {
         final detail = harness.container.read(
           playlistDetailProvider(playlist.id),
         );
@@ -157,7 +158,7 @@ void main() {
       );
       expect(result, isNotNull);
 
-      await harness.pumpUntil(() {
+      await pumpUntil(() {
         final detail = harness.container.read(
           playlistDetailProvider(playlist.id),
         );
@@ -200,24 +201,6 @@ class PlaylistPhase2Harness {
       container.invalidate(allPlaylistsProvider);
     }
     return container.read(allPlaylistsProvider.future);
-  }
-
-  Future<void> pumpUntil(
-    bool Function() condition, {
-    required String reason,
-    Duration timeout = const Duration(seconds: 2),
-  }) async {
-    final deadline = DateTime.now().add(timeout);
-    while (DateTime.now().isBefore(deadline)) {
-      if (condition()) {
-        return;
-      }
-      await Future<void>.delayed(const Duration(milliseconds: 10));
-    }
-
-    if (!condition()) {
-      fail(reason);
-    }
   }
 
   Future<void> dispose() async {

--- a/test/providers/refresh_provider_stale_cleanup_test.dart
+++ b/test/providers/refresh_provider_stale_cleanup_test.dart
@@ -19,6 +19,7 @@ import 'package:fmp/providers/search/refresh_provider.dart';
 import 'package:fmp/services/import/import_service.dart';
 import 'package:isar_community/isar.dart';
 import '../support/isar_test_harness.dart';
+import '../support/pump_until.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -47,7 +48,7 @@ void main() {
         );
         final parse = harness.source.enqueueParse();
         final refreshFuture = notifier.refreshPlaylist(playlist);
-        await _pumpUntil(
+        await pumpUntil(
           () => harness.source.parseCalls == 1,
           reason: 'refresh should reach playlist parsing',
         );
@@ -81,7 +82,7 @@ void main() {
         );
         final parse = harness.source.enqueueParse();
         final firstRefresh = notifier.refreshPlaylist(playlist);
-        await _pumpUntil(
+        await pumpUntil(
           () => harness.source.parseCalls == 1,
           reason: 'first refresh should reach playlist parsing',
         );
@@ -121,7 +122,7 @@ void main() {
         final refreshFuture = harness.container
             .read(refreshManagerProvider.notifier)
             .refreshPlaylist(playlist);
-        await _pumpUntil(
+        await pumpUntil(
           () => harness.source.parseCalls == 1,
           reason: 'refresh should reach playlist parsing',
         );
@@ -153,7 +154,7 @@ void main() {
 
       final firstParse = harness.source.enqueueParse();
       final firstFuture = notifier.refreshPlaylist(playlist);
-      await _pumpUntil(
+      await pumpUntil(
         () => harness.source.parseCalls == 1,
         reason: 'first refresh should reach playlist parsing',
       );
@@ -170,7 +171,7 @@ void main() {
 
       final secondParse = harness.source.enqueueParse();
       final secondFuture = notifier.refreshPlaylist(playlist);
-      await _pumpUntil(
+      await pumpUntil(
         () => harness.source.parseCalls == 2,
         reason: 'second refresh should start before old cleanup fires',
       );
@@ -374,17 +375,4 @@ Track _track(String sourceId, {int? pageCount}) {
     ..pageCount = pageCount
     ..title = 'Track $sourceId'
     ..artist = 'Refresh Tester';
-}
-
-Future<void> _pumpUntil(
-  bool Function() condition, {
-  required String reason,
-  Duration timeout = const Duration(seconds: 2),
-}) async {
-  final deadline = DateTime.now().add(timeout);
-  while (DateTime.now().isBefore(deadline)) {
-    if (condition()) return;
-    await Future<void>.delayed(const Duration(milliseconds: 10));
-  }
-  if (!condition()) fail(reason);
 }

--- a/test/providers/search_pagination_stale_test.dart
+++ b/test/providers/search_pagination_stale_test.dart
@@ -12,6 +12,7 @@ import 'package:fmp/data/repositories/track_repository.dart';
 import 'package:fmp/data/sources/source_provider.dart';
 
 import '../support/fakes/fake_isar.dart';
+import '../support/pump_until.dart';
 
 void main() {
   group('SearchNotifier stale pagination guards', () {
@@ -59,7 +60,10 @@ void main() {
         );
 
         final loadMoreFuture = notifier.loadMore(SourceIds.youtube);
-        await pumpEventQueue(times: 2);
+        await pumpUntil(
+          () => service.sourceCalls.isNotEmpty,
+          reason: 'load more should reach the search service',
+        );
         expect(service.sourceCalls.single.query, 'old query');
 
         notifier.setSeedState(
@@ -129,7 +133,10 @@ void main() {
         );
 
         final loadMoreFuture = notifier.loadMoreAll();
-        await pumpEventQueue(times: 2);
+        await pumpUntil(
+          () => service.sourceCalls.length == 2,
+          reason: 'load-more-all should reach both sources',
+        );
         expect(service.sourceCalls, hasLength(2));
 
         notifier.setSeedState(
@@ -199,7 +206,10 @@ void main() {
         );
 
         final loadMoreFuture = notifier.loadMoreLiveRooms();
-        await pumpEventQueue(times: 2);
+        await pumpUntil(
+          () => liveSource.calls.isNotEmpty,
+          reason: 'live-room load more should reach the source',
+        );
         expect(liveSource.calls.single, 'live query:2:online');
 
         notifier.setSeedState(
@@ -309,7 +319,10 @@ void main() {
         );
 
         notifier.setSource(SourceIds.netease);
-        await pumpEventQueue(times: 2);
+        await pumpUntil(
+          () => notifier.state.isLoading,
+          reason: 'switching source should start a new search',
+        );
 
         expect(notifier.state.isLoading, isTrue);
         expect(
@@ -320,7 +333,10 @@ void main() {
         );
 
         gate.complete();
-        await pumpEventQueue(times: 2);
+        await pumpUntil(
+          () => !notifier.state.isLoading,
+          reason: 'the new search should finish once its gate opens',
+        );
 
         expect(notifier.state.isLoading, isFalse);
         expect(notifier.state.onlineResults.keys, [SourceIds.netease]);
@@ -362,7 +378,10 @@ void main() {
         );
 
         notifier.setSearchOrder(SearchOrder.playCount);
-        await pumpEventQueue(times: 2);
+        await pumpUntil(
+          () => notifier.state.isLoading,
+          reason: 'changing the order should start a new search',
+        );
 
         expect(notifier.state.searchOrder, SearchOrder.playCount);
         expect(notifier.state.isLoading, isTrue);
@@ -374,7 +393,10 @@ void main() {
         );
 
         gate.complete();
-        await pumpEventQueue(times: 2);
+        await pumpUntil(
+          () => !notifier.state.isLoading,
+          reason: 'the reordered search should finish once its gate opens',
+        );
 
         expect(notifier.state.isLoading, isFalse);
         expect(
@@ -403,7 +425,10 @@ void main() {
       );
 
       final searchFuture = notifier.search('slow query');
-      await pumpEventQueue(times: 2);
+      await pumpUntil(
+        () => notifier.state.isLoading,
+        reason: 'the slow search should be in flight before it is cleared',
+      );
 
       notifier.clear();
       onlineGate.complete();
@@ -420,7 +445,10 @@ void main() {
       );
 
       final searchFuture = notifier.searchLiveRooms('slow live');
-      await pumpEventQueue(times: 2);
+      await pumpUntil(
+        () => liveSource.calls.isNotEmpty,
+        reason: 'the slow live search should reach the source',
+      );
       expect(liveSource.calls.single, 'slow live:1:online');
 
       notifier.clear();

--- a/test/providers/track_detail_refresh_stale_test.dart
+++ b/test/providers/track_detail_refresh_stale_test.dart
@@ -13,6 +13,8 @@ import 'package:fmp/providers/library/track_detail_provider.dart';
 import 'package:fmp/services/account/source_auth_context.dart';
 import 'package:path/path.dart' as p;
 
+import '../support/pump_until.dart';
+
 void main() {
   test(
     'loadDetail treats same-source multi-page tracks as different tracks',
@@ -35,12 +37,18 @@ void main() {
         ..pageNum = 2;
 
       final firstLoad = notifier.loadDetail(pageOne);
-      await pumpEventQueue(times: 2);
+      await pumpUntil(
+        () => bilibili.requests.length == 1,
+        reason: 'the first load should reach the source',
+      );
       bilibili.complete('BV-SAME', _detail('BV-SAME', 'Page One'));
       await firstLoad;
 
       final secondLoad = notifier.loadDetail(pageTwo);
-      await pumpEventQueue(times: 2);
+      await pumpUntil(
+        () => bilibili.requests.length == 2,
+        reason: 'a different page of the same id should re-request',
+      );
 
       expect(bilibili.requests, ['BV-SAME', 'BV-SAME']);
 
@@ -64,16 +72,25 @@ void main() {
     final trackB = _track('YT-B', SourceIds.youtube);
 
     final initialLoadFuture = notifier.loadDetail(trackA);
-    await pumpEventQueue(times: 2);
+    await pumpUntil(
+      () => bilibili.requests.length == 1,
+      reason: 'the initial load should reach the source',
+    );
     bilibili.complete('BV-A', _detail('BV-A', 'Track A initial'));
     await initialLoadFuture;
 
     final refreshFuture = notifier.refresh();
-    await pumpEventQueue(times: 2);
+    await pumpUntil(
+      () => bilibili.requests.length == 2,
+      reason: 'refresh should re-request the same track',
+    );
     expect(bilibili.requests, ['BV-A', 'BV-A']);
 
     final loadTrackBFuture = notifier.loadDetail(trackB);
-    await pumpEventQueue(times: 2);
+    await pumpUntil(
+      () => youtube.requests.length == 1,
+      reason: 'switching tracks should reach the other source',
+    );
     youtube.complete('YT-B', _detail('YT-B', 'Track B'));
     await loadTrackBFuture;
 
@@ -99,7 +116,10 @@ void main() {
 
       final trackA = _track('BV-A', SourceIds.bilibili);
       final initialLoadFuture = notifier.loadDetail(trackA);
-      await pumpEventQueue(times: 2);
+      await pumpUntil(
+        () => bilibili.requests.length == 1,
+        reason: 'the initial load should reach the source',
+      );
       bilibili.complete('BV-A', _detail('BV-A', 'Track A'));
       await initialLoadFuture;
 
@@ -107,7 +127,10 @@ void main() {
 
       final trackB = _track('YT-B', SourceIds.youtube);
       final loadTrackBFuture = notifier.loadDetail(trackB);
-      await pumpEventQueue(times: 2);
+      await pumpUntil(
+        () => youtube.requests.length == 1,
+        reason: 'switching tracks should reach the other source',
+      );
 
       expect(notifier.state.isLoading, isTrue);
       expect(notifier.state.detail, isNull);
@@ -135,7 +158,10 @@ void main() {
 
     final track = _track('YT-B', SourceIds.youtube);
     final loadFuture = notifier.loadDetail(track);
-    await pumpEventQueue(times: 2);
+    await pumpUntil(
+      () => youtube.requests.length == 1,
+      reason: 'the load should reach the source',
+    );
 
     youtube.completeError('YT-B', Exception('blocked'));
     await loadFuture;
@@ -145,7 +171,10 @@ void main() {
     expect(notifier.state.error, isNot(contains('blocked')));
 
     final refreshFuture = notifier.refresh();
-    await pumpEventQueue(times: 2);
+    await pumpUntil(
+      () => youtube.requests.length == 2,
+      reason: 'refresh after an error should re-request',
+    );
 
     expect(youtube.requests, ['YT-B', 'YT-B']);
 
@@ -219,7 +248,10 @@ void main() {
       final notifier = _notifier(sourceManager, _FakeSourceAuthContext());
 
       final loadFuture = notifier.loadDetail(track);
-      await pumpEventQueue(times: 2);
+      await pumpUntil(
+        () => bilibili.requests.length == 1,
+        reason: 'the load should reach the source',
+      );
       bilibili.completeError(
         'BV-STATE',
         StateError('simulated detail failure'),
@@ -245,7 +277,10 @@ void main() {
     final loadFuture = notifier.loadDetail(
       _track('YT-auth', SourceIds.youtube),
     );
-    await pumpEventQueue(times: 2);
+    await pumpUntil(
+      () => youtube.requests.length == 1,
+      reason: 'the load should reach the source',
+    );
     youtube.complete('YT-auth', _detail('YT-auth', 'Auth detail'));
     await loadFuture;
 

--- a/test/providers/update_provider_test.dart
+++ b/test/providers/update_provider_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:fmp/providers/system/update_provider.dart';
 import 'package:fmp/services/update/update_service.dart';
+import '../support/pump_until.dart';
 
 void main() {
   group('UpdateNotifier operation generation', () {
@@ -15,11 +16,17 @@ void main() {
 
         final oldCheck = service.enqueueCheck(_info('v9.9.8'));
         final oldFuture = notifier.checkForUpdate();
-        await pumpEventQueue(times: 2);
+        await pumpUntil(
+          () => service.checkCallCount == 1,
+          reason: 'the old check should be in flight',
+        );
 
         final newCheck = service.enqueueCheck(null);
         final newFuture = notifier.checkForUpdate();
-        await pumpEventQueue(times: 2);
+        await pumpUntil(
+          () => service.checkCallCount == 2,
+          reason: 'the newer check should supersede the old one',
+        );
 
         newCheck.complete();
         await newFuture;
@@ -45,7 +52,10 @@ void main() {
 
         final download = service.enqueueDownload('/tmp/fmp-update.zip');
         final downloadFuture = notifier.downloadAndInstall();
-        await pumpEventQueue(times: 2);
+        await pumpUntil(
+          () => service.progressCallbacks.isNotEmpty,
+          reason: 'the download should register its progress callback',
+        );
 
         service.progressCallbacks.single(50, 100);
         expect(notifier.state.downloadProgress, 0.5);
@@ -71,7 +81,10 @@ void main() {
 
       final download = service.enqueueDownload('/tmp/fmp-update.apk');
       final downloadFuture = notifier.downloadAndInstall();
-      await pumpEventQueue(times: 2);
+      await pumpUntil(
+        () => service.downloadCallCount == 1,
+        reason: 'the download should be in flight',
+      );
 
       download.complete();
       await downloadFuture;
@@ -98,6 +111,10 @@ class _FakeUpdateService extends UpdateService {
   final List<void Function(int received, int total)> progressCallbacks = [];
   bool canInstallPackages = true;
   int installCalls = 0;
+
+  /// 已經被呼叫幾次。單調遞增，所以 `pumpUntil` 等得到「請求真的送出去了」。
+  int checkCallCount = 0;
+  int downloadCallCount = 0;
 
   Completer<void> enqueueCheck(UpdateInfo? info) {
     final gate = Completer<void>();
@@ -129,6 +146,7 @@ class _FakeUpdateService extends UpdateService {
 
   @override
   Future<UpdateInfo?> checkForUpdate() {
+    checkCallCount++;
     return _checks.removeAt(0).future;
   }
 
@@ -140,6 +158,7 @@ class _FakeUpdateService extends UpdateService {
     UpdateInfo info, {
     void Function(int received, int total)? onProgress,
   }) {
+    downloadCallCount++;
     if (onProgress != null) {
       progressCallbacks.add(onProgress);
     }

--- a/test/providers/update_provider_test.dart
+++ b/test/providers/update_provider_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:fmp/providers/system/update_provider.dart';
 import 'package:fmp/services/update/update_service.dart';
+
 import '../support/pump_until.dart';
 
 void main() {

--- a/test/services/audio/audio_auth_retry_phase4_test.dart
+++ b/test/services/audio/audio_auth_retry_phase4_test.dart
@@ -28,6 +28,7 @@ import '../../support/fakes/fake_audio_service.dart';
 import '../../support/fakes/fake_source_auth_context.dart';
 import '../../support/isar_test_harness.dart';
 import '../../support/now_playing.dart';
+import '../../support/pump_until.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -111,11 +112,17 @@ void main() {
         final track = _track('retry-track');
 
         await controller.playTrack(track);
-        await pumpEventQueue(times: 10);
+        await pumpUntil(
+          () => controller.state.isPlaying,
+          reason: 'the track should be playing before the transport fails',
+        );
 
         audioService.emitPosition(const Duration(seconds: 47));
         audioService.emitTransportFailure('network timeout during playback');
-        await pumpEventQueue(times: 10);
+        await pumpUntil(
+          () => controller.state.isRetrying,
+          reason: 'a transport failure should start a retry',
+        );
 
         expect(controller.state.isRetrying, isTrue);
         expect(controller.state.isNetworkError, isTrue);
@@ -125,7 +132,12 @@ void main() {
         audioService.seekCalls.clear();
 
         await controller.retryManually();
-        await pumpEventQueue(times: 20);
+        await pumpUntil(
+          () =>
+              audioService.playUrlCalls.isNotEmpty &&
+              audioService.seekCalls.isNotEmpty,
+          reason: 'a manual retry should replay and restore the position',
+        );
 
         expect(
           audioService.playUrlCalls.single.url,
@@ -143,11 +155,17 @@ void main() {
         final track = _track('auto-recovery-track');
 
         await controller.playTrack(track);
-        await pumpEventQueue(times: 10);
+        await pumpUntil(
+          () => controller.state.isPlaying,
+          reason: 'the track should be playing before the transport fails',
+        );
 
         audioService.emitPosition(const Duration(seconds: 31));
         audioService.emitTransportFailure('network timeout during playback');
-        await pumpEventQueue(times: 10);
+        await pumpUntil(
+          () => controller.state.isRetrying,
+          reason: 'a transport failure should start a retry',
+        );
 
         expect(controller.state.isRetrying, isTrue);
         expect(controller.state.isNetworkError, isTrue);
@@ -160,7 +178,9 @@ void main() {
         networkRecoveryController.add(null);
         await audioService.waitForPlayUrlCallCount(1);
         await audioService.waitForSeekCallCount(1);
-        await pumpEventQueue(times: 20);
+        await drainEventQueue(
+          reason: 'let the recovery finish before the state is judged',
+        );
 
         expect(
           audioService.playUrlCalls.single.url,
@@ -182,11 +202,17 @@ void main() {
         final track = _track('handoff-network-error-track');
 
         await controller.playTrack(track);
-        await pumpEventQueue(times: 10);
+        await pumpUntil(
+          () => controller.state.isPlaying,
+          reason: 'the track should be playing before the transport fails',
+        );
 
         audioService.emitPosition(const Duration(seconds: 29));
         audioService.emitTransportFailure('network timeout during playback');
-        await pumpEventQueue(times: 10);
+        await pumpUntil(
+          () => controller.state.isRetrying,
+          reason: 'a transport failure should start a retry',
+        );
 
         expect(controller.state.currentTrack?.sourceId, track.sourceId);
         expect(controller.state.isRetrying, isTrue);
@@ -198,16 +224,23 @@ void main() {
 
         final manualRetry = controller.retryManually();
         await audioService.waitForPlayUrlCallCount(1);
-        await pumpEventQueue(times: 2);
+        await drainEventQueue(
+          reason: 'let the retry request reach the gated backend call',
+        );
 
         audioService.emitTransportFailure(
           'tcp: ffurl_read returned 0xffffd8ba',
         );
-        await pumpEventQueue(times: 10);
+        await drainEventQueue(
+          reason: 'let the second failure reach the controller',
+        );
 
         retryHandoff.complete();
         await manualRetry;
-        await pumpEventQueue(times: 20);
+        await pumpUntil(
+          () => controller.state.nextRetryAt != null,
+          reason: 'a failure during the handoff should schedule a fresh retry',
+        );
 
         expect(controller.state.currentTrack?.sourceId, track.sourceId);
         expect(controller.state.isRetrying, isTrue);
@@ -224,7 +257,10 @@ void main() {
         final secondTrack = _track('network-error-next');
 
         await controller.playAll([firstTrack, secondTrack]);
-        await pumpEventQueue(times: 10);
+        await pumpUntil(
+          () => controller.state.isPlaying,
+          reason: 'the first track should be playing before it fails',
+        );
 
         audioService.playUrlCalls.clear();
         audioService.setDurationValue(const Duration(minutes: 4));
@@ -234,7 +270,10 @@ void main() {
         audioService.emitTransportFailure(
           'tcp: ffurl_read returned 0xffffd8ba',
         );
-        await pumpEventQueue(times: 20);
+        await pumpUntil(
+          () => controller.state.isRetrying,
+          reason: 'a mid-track network error should retry, not advance',
+        );
 
         expect(
           controller.state.currentTrack?.sourceId,
@@ -257,14 +296,20 @@ void main() {
         final secondTrack = _track('premature-complete-next');
 
         await controller.playAll([firstTrack, secondTrack]);
-        await pumpEventQueue(times: 10);
+        await pumpUntil(
+          () => controller.state.isPlaying,
+          reason: 'the first track should be playing before it completes',
+        );
 
         audioService.playUrlCalls.clear();
         audioService.setDurationValue(const Duration(minutes: 5));
         audioService.emitPosition(const Duration(minutes: 4));
 
         audioService.emitCompleted();
-        await pumpEventQueue(times: 20);
+        await pumpUntil(
+          () => controller.state.isRetrying,
+          reason: 'a premature completion should retry the current track',
+        );
 
         expect(
           controller.state.currentTrack?.sourceId,
@@ -287,11 +332,17 @@ void main() {
         final newTrack = _track('new-user-track');
 
         await controller.playTrack(oldTrack);
-        await pumpEventQueue(times: 10);
+        await pumpUntil(
+          () => controller.state.isPlaying,
+          reason: 'the old track should be playing before the transport fails',
+        );
 
         audioService.emitPosition(const Duration(seconds: 19));
         audioService.emitTransportFailure('network timeout during playback');
-        await pumpEventQueue(times: 10);
+        await pumpUntil(
+          () => controller.state.isRetrying,
+          reason: 'a transport failure should start a retry',
+        );
 
         expect(controller.state.isRetrying, isTrue);
         expect(controller.state.currentTrack?.sourceId, 'old-network-track');
@@ -300,17 +351,26 @@ void main() {
         audioService.seekCalls.clear();
 
         networkRecoveryController.add(null);
-        await pumpEventQueue(times: 2);
+        await drainEventQueue(
+          reason: 'let recovery start while the user switches tracks',
+        );
 
         await controller.playTrack(newTrack);
-        await pumpEventQueue(times: 10);
+        await pumpUntil(
+          () => controller.state.currentTrack?.sourceId == 'new-user-track',
+          reason: 'the user switch should take over the current track',
+        );
         expect(controller.state.currentTrack?.sourceId, 'new-user-track');
 
         audioService.playUrlCalls.clear();
         audioService.seekCalls.clear();
 
+        // 舊軌的穩定化視窗排在 500ms 後；睡過那個時點才有資格說它沒有重啟。
         await Future<void>.delayed(const Duration(milliseconds: 600));
-        await pumpEventQueue(times: 20);
+        await drainEventQueue(
+          reason:
+              'the old track must not restart after the stabilization window',
+        );
 
         expect(audioService.playUrlCalls, isEmpty);
         expect(audioService.seekCalls, isEmpty);
@@ -325,12 +385,18 @@ void main() {
         final newTrack = _track('new-delayed-stop-track');
 
         await controller.playTrack(oldTrack);
-        await pumpEventQueue(times: 10);
+        await pumpUntil(
+          () => controller.state.isPlaying,
+          reason: 'the old track should be playing before the transport fails',
+        );
 
         audioService.emitPosition(const Duration(seconds: 21));
         final delayedStop = audioService.enqueuePendingStop();
         audioService.emitTransportFailure('network timeout during playback');
-        await pumpEventQueue(times: 2);
+        await drainEventQueue(
+          reason:
+              'let the failure reach the controller while the stop is gated',
+        );
 
         expect(
           controller.state.currentTrack?.sourceId,
@@ -341,7 +407,12 @@ void main() {
 
         delayedStop.complete();
         await newPlayback;
-        await pumpEventQueue(times: 20);
+        await pumpUntil(
+          () =>
+              controller.state.currentTrack?.sourceId ==
+              'new-delayed-stop-track',
+          reason: 'the newer track should survive the delayed backend stop',
+        );
 
         expect(
           controller.state.currentTrack?.sourceId,
@@ -372,7 +443,10 @@ void main() {
         expect(sourceError.kind, SourceErrorKind.network);
 
         await controller.playTrack(track);
-        await pumpEventQueue(times: 20);
+        await pumpUntil(
+          () => controller.state.isRetrying,
+          reason: 'a typed network error should schedule a retry',
+        );
 
         expect(controller.state.isRetrying, isTrue);
         expect(controller.state.isNetworkError, isTrue);
@@ -391,7 +465,10 @@ void main() {
         );
 
         await controller.playTrack(track);
-        await pumpEventQueue(times: 20);
+        await pumpUntil(
+          () => controller.state.error != null,
+          reason: 'a permission error should surface instead of retrying',
+        );
 
         expect(controller.state.isRetrying, isFalse);
         expect(controller.state.isNetworkError, isFalse);

--- a/test/services/audio/audio_controller_mix_boundary_test.dart
+++ b/test/services/audio/audio_controller_mix_boundary_test.dart
@@ -372,45 +372,29 @@ void main() {
   });
 }
 
+/// `pumpUntil` 加上一段只有這裡需要的診斷：逾時的時候把實際打過的 playUrl 與
+/// 當前曲目印出來，否則「等不到第 3 次呼叫」這種訊息幫不上忙。
 Future<void> _waitForPlayUrlCallCount(
   FakeAudioService audioService,
   AudioController controller,
   int count, {
   Duration timeout = const Duration(seconds: 5),
 }) async {
-  var waitComplete = audioService.playUrlCalls.length >= count;
-  Object? waitError;
-  StackTrace? waitStackTrace;
-  if (!waitComplete) {
-    unawaited(
-      audioService
-          .waitForPlayUrlCallCount(count)
-          .then((_) {
-            waitComplete = true;
-          })
-          .catchError((Object error, StackTrace stackTrace) {
-            waitError = error;
-            waitStackTrace = stackTrace;
-          }),
+  try {
+    await pumpUntil(
+      () => audioService.playUrlCalls.length >= count,
+      reason: 'the backend should receive $count playUrl calls',
+      timeout: timeout,
     );
-  }
-
-  final stopwatch = Stopwatch()..start();
-  while (!waitComplete && audioService.playUrlCalls.length < count) {
-    if (waitError != null) {
-      Error.throwWithStackTrace(waitError!, waitStackTrace!);
-    }
-    if (stopwatch.elapsed >= timeout) {
-      final playUrlCalls = audioService.playUrlCalls
-          .map((call) => '${call.track?.sourceId ?? 'unknown'} => ${call.url}')
-          .toList();
-      fail(
-        'Timed out waiting for $count playUrl calls after $timeout. '
-        'playUrlCalls=$playUrlCalls, '
-        'currentTrack=${controller.state.currentTrack?.sourceId}',
-      );
-    }
-    await pumpEventQueue();
+  } on TestFailure {
+    final playUrlCalls = audioService.playUrlCalls
+        .map((call) => '${call.track?.sourceId ?? 'unknown'} => ${call.url}')
+        .toList();
+    fail(
+      'Timed out waiting for $count playUrl calls after $timeout. '
+      'playUrlCalls=$playUrlCalls, '
+      'currentTrack=${controller.state.currentTrack?.sourceId}',
+    );
   }
 }
 

--- a/test/services/audio/audio_controller_mix_boundary_test.dart
+++ b/test/services/audio/audio_controller_mix_boundary_test.dart
@@ -26,6 +26,7 @@ import '../../support/fakes/fake_audio_service.dart';
 import '../../support/fakes/fake_source_auth_context.dart';
 import '../../support/isar_test_harness.dart';
 import '../../support/now_playing.dart';
+import '../../support/pump_until.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -190,7 +191,12 @@ void main() {
         );
 
         await controller.initialize();
-        await pumpEventQueue(times: 10);
+        await pumpUntil(
+          () =>
+              controller.queueState.isMixMode &&
+              controller.state.currentTrack?.sourceId == 'restored-b',
+          reason: 'startup should restore the persisted mix session',
+        );
 
         expect(controller.queueState.isMixMode, isTrue);
         expect(controller.queueState.mixTitle, 'Restored Mix');
@@ -214,7 +220,10 @@ void main() {
         loadMoreGate.complete();
         await loadMoreApplied.future;
         await queueSub.cancel();
-        await pumpEventQueue(times: 5);
+        await pumpUntil(
+          () => !controller.queueState.isLoadingMoreMix,
+          reason: 'the restored mix should finish loading more',
+        );
 
         expect(controller.queueState.isLoadingMoreMix, isFalse);
         expect(
@@ -276,15 +285,22 @@ void main() {
         );
 
         final mixFuture = controller.startMixFromPlaylist(playlist);
-        await pumpEventQueue(times: 2);
+        await drainEventQueue(
+          reason: 'let the mix request reach its gated fetch',
+        );
 
         await controller.playTrack(_track('new-direct-track', title: 'Direct'));
-        await pumpEventQueue(times: 10);
+        await pumpUntil(
+          () => controller.state.currentTrack?.sourceId == 'new-direct-track',
+          reason: 'the direct play should take over from the pending mix',
+        );
         expect(controller.state.currentTrack?.sourceId, 'new-direct-track');
 
         mixGate.complete();
         await mixFuture;
-        await pumpEventQueue(times: 10);
+        await drainEventQueue(
+          reason: 'the superseded mix must not take the queue back',
+        );
 
         expect(controller.state.currentTrack?.sourceId, 'new-direct-track');
         expect(controller.queueState.isMixMode, isFalse);
@@ -324,7 +340,12 @@ void main() {
         );
 
         await controller.next();
-        await pumpEventQueue(times: 5);
+        await pumpUntil(
+          () =>
+              controller.state.currentTrack?.sourceId == 'mix-b' &&
+              controller.queueState.isLoadingMoreMix,
+          reason: 'advancing into the last mix track should load more',
+        );
 
         expect(controller.state.currentTrack?.sourceId, 'mix-b');
         expect(controller.queueState.isLoadingMoreMix, isTrue);
@@ -335,7 +356,9 @@ void main() {
           3,
         );
         audioService.emitNaturalCompletion();
-        await pumpEventQueue(times: 5);
+        await drainEventQueue(
+          reason: 'let the completion be handled before the fetch returns',
+        );
         loadMoreGate.complete();
 
         await nextTrackPlayed;

--- a/test/services/audio/audio_controller_next_medium_test.dart
+++ b/test/services/audio/audio_controller_next_medium_test.dart
@@ -26,6 +26,7 @@ import '../../support/fakes/fake_audio_service.dart';
 import '../../support/fakes/fake_source_auth_context.dart';
 import '../../support/isar_test_harness.dart';
 import '../../support/now_playing.dart';
+import '../../support/pump_until.dart';
 
 /// 把「下一首」交給後端之後，推進權在後端手上：交界不會有 `EndedNaturally`，
 /// 控制器改成跟隨 `advancedToNext`。
@@ -100,16 +101,6 @@ void main() {
       }
     });
 
-    /// 條件式等待。固定圈數的 `pumpEventQueue` 在滿載的套件裡會變成計時競態
-    /// （issue #43、#55 都是那個形狀）。
-    Future<void> waitFor(bool Function() done, String what) async {
-      final deadline = DateTime.now().add(const Duration(seconds: 10));
-      while (!done()) {
-        if (DateTime.now().isAfter(deadline)) fail('timed out waiting: $what');
-        await Future<void>.delayed(const Duration(milliseconds: 10));
-      }
-    }
-
     Future<void> playPair() async {
       await controller.playAll([
         _track('alpha', title: 'Alpha'),
@@ -119,9 +110,9 @@ void main() {
 
     test('playing a queue hands the next medium to the backend', () async {
       await playPair();
-      await waitFor(
+      await pumpUntil(
         () => audioService.setNextMediaCalls.isNotEmpty,
-        'the next medium to be armed',
+        reason: 'the next medium to be armed',
       );
 
       final armed = audioService.setNextMediaCalls.single;
@@ -138,40 +129,40 @@ void main() {
       await playPair();
 
       // 等預取真的跑完再做否定斷言，否則只是在賭時序。
-      await waitFor(
+      await pumpUntil(
         () => sourceManager.resolveCount['beta'] != null,
-        'the next track to be prefetched',
+        reason: 'the next track to be prefetched',
       );
       expect(audioService.setNextMediaCalls, isEmpty);
     });
 
     test('a queue mutation takes the next medium back', () async {
       await playPair();
-      await waitFor(
+      await pumpUntil(
         () => audioService.setNextMediaCalls.isNotEmpty,
-        'the next medium to be armed',
+        reason: 'the next medium to be armed',
       );
 
       await controller.addNext(_track('gamma', title: 'Gamma'));
 
-      await waitFor(
+      await pumpUntil(
         () => audioService.setNextMediaCalls.contains(null),
-        'the arm to be cleared',
+        reason: 'the arm to be cleared',
       );
     });
 
     test('switching to loop-one takes the next medium back', () async {
       await playPair();
-      await waitFor(
+      await pumpUntil(
         () => audioService.setNextMediaCalls.isNotEmpty,
-        'the next medium to be armed',
+        reason: 'the next medium to be armed',
       );
 
       await controller.setLoopMode(LoopMode.one);
 
-      await waitFor(
+      await pumpUntil(
         () => audioService.setNextMediaCalls.contains(null),
-        'the arm to be cleared',
+        reason: 'the arm to be cleared',
       );
     });
 
@@ -182,18 +173,18 @@ void main() {
         _track('gamma', title: 'Gamma'),
         _track('delta', title: 'Delta'),
       ]);
-      await waitFor(
+      await pumpUntil(
         () => audioService.setNextMediaCalls.isNotEmpty,
-        'the next medium to be armed',
+        reason: 'the next medium to be armed',
       );
 
       final versionBefore = controller.queueState.queueVersion;
       await controller.toggleShuffle();
       // `queueVersion` 只在 `_updateQueueState` 裡前進，而 disarm 的網就掛在
       // 那裡 —— 等它跑過一輪才有東西可以斷言。
-      await waitFor(
+      await pumpUntil(
         () => controller.queueState.queueVersion > versionBefore,
-        'the queue state to be recomputed',
+        reason: 'the queue state to be recomputed',
       );
 
       // 打亂之後「下一首」有機會剛好還是同一首，所以不能斷言一定 disarm ——
@@ -207,9 +198,9 @@ void main() {
 
     test('the controller follows the backend across the boundary', () async {
       await playPair();
-      await waitFor(
+      await pumpUntil(
         () => audioService.setNextMediaCalls.isNotEmpty,
-        'the next medium to be armed',
+        reason: 'the next medium to be armed',
       );
       final armed = audioService.setNextMediaCalls.single!;
 
@@ -218,9 +209,9 @@ void main() {
       final stoppedBefore = audioService.stopCallCount;
 
       audioService.emitAdvancedToNext(armed);
-      await waitFor(
+      await pumpUntil(
         () => controller.state.playingTrack?.sourceId == 'beta',
-        'the controller to follow the backend',
+        reason: 'the controller to follow the backend',
       );
 
       expect(queueManager.currentIndex, 1, reason: 'exactly one step');
@@ -245,33 +236,33 @@ void main() {
         _track('beta', title: 'Beta'),
         _track('gamma', title: 'Gamma'),
       ]);
-      await waitFor(
+      await pumpUntil(
         () => audioService.setNextMediaCalls.isNotEmpty,
-        'the first medium to be armed',
+        reason: 'the first medium to be armed',
       );
       final first = audioService.setNextMediaCalls.single!;
       expect(first.track.sourceId, 'beta');
 
       audioService.emitAdvancedToNext(first);
 
-      await waitFor(
+      await pumpUntil(
         () => audioService.setNextMediaCalls.last?.track.sourceId == 'gamma',
-        'the next boundary to be armed',
+        reason: 'the next boundary to be armed',
       );
     });
 
     test('the boundary replaces the stream metadata', () async {
       await playPair();
-      await waitFor(
+      await pumpUntil(
         () => audioService.setNextMediaCalls.isNotEmpty,
-        'the next medium to be armed',
+        reason: 'the next medium to be armed',
       );
       expect(controller.state.currentContainer, 'alpha-m4a');
 
       audioService.emitAdvancedToNext(audioService.setNextMediaCalls.single!);
-      await waitFor(
+      await pumpUntil(
         () => controller.state.playingTrack?.sourceId == 'beta',
-        'the controller to follow the backend',
+        reason: 'the controller to follow the backend',
       );
 
       // 這四個值屬於當前播放請求。跟隨路徑不經過 `_exitLoadingState`，忘了補
@@ -287,9 +278,9 @@ void main() {
 
     test('an unrecognised advance falls back to the completion path', () async {
       await playPair();
-      await waitFor(
+      await pumpUntil(
         () => audioService.setNextMediaCalls.isNotEmpty,
-        'the next medium to be armed',
+        reason: 'the next medium to be armed',
       );
 
       // 後端接上去的不是控制器交出去的那一個 —— 沒有安全的跟隨方式。
@@ -301,9 +292,9 @@ void main() {
         ),
       );
 
-      await waitFor(
+      await pumpUntil(
         () => queueManager.currentIndex == 1,
-        'the completion path to advance the queue',
+        reason: 'the completion path to advance the queue',
       );
     });
   });

--- a/test/services/audio/audio_controller_phase1_test.dart
+++ b/test/services/audio/audio_controller_phase1_test.dart
@@ -42,6 +42,7 @@ import '../../support/fakes/fake_audio_service.dart';
 import '../../support/fakes/fake_source_auth_context.dart';
 import '../../support/isar_test_harness.dart';
 import '../../support/now_playing.dart';
+import '../../support/pump_until.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -166,12 +167,19 @@ void main() {
       await lyricsService.waitForCallCount(2);
 
       firstGate.complete();
-      await pumpEventQueue(times: 10);
+      // 作廢的第一次比對不該再推狀態。下面等到第三筆出現時 list 的內容就是證據，
+      // 這裡只是先把在途工作放完。
+      await drainEventQueue(
+        reason: 'the superseded first match must not push a state',
+      );
 
       expect(states, [true, true]);
 
       secondGate.complete();
-      await pumpEventQueue(times: 10);
+      await pumpUntil(
+        () => states.length == 3,
+        reason: 'the second lyrics match should settle',
+      );
 
       expect(states, [true, true, false]);
     });
@@ -220,7 +228,10 @@ void main() {
           _track('lyrics-disabled', title: 'Disabled'),
         );
         await lyricsService.waitForCallCount(1);
-        await pumpEventQueue(times: 10);
+        await pumpUntil(
+          () => lyricsService.enabledSourceCalls.length == 1,
+          reason: 'the auto-match call should record its enabled source list',
+        );
 
         expect(lyricsService.enabledSourceCalls.single, isEmpty);
       },
@@ -266,7 +277,10 @@ void main() {
         audioService.emitNaturalCompletion();
         await restoreSetUrl;
         await restoreSeek;
-        await pumpEventQueue(times: 20);
+        await pumpUntil(
+          () => controller.state.playingTrack?.sourceId == 'queue-b',
+          reason: 'natural completion should advance to the next queue entry',
+        );
 
         expect(controller.state.playingTrack?.sourceId, 'queue-b');
         expect(controller.state.currentTrack?.sourceId, 'queue-b');
@@ -325,7 +339,10 @@ void main() {
         final pendingNextLoad = audioService.enqueuePendingPlayUrl();
         final nextFuture = controller.next();
         await audioService.waitForPlayUrlCallCount(2);
-        await pumpEventQueue(times: 5);
+        await pumpUntil(
+          () => handler.mediaItem.value?.title == 'Notification Next',
+          reason: 'the notification should show the next track while it loads',
+        );
 
         expect(handler.mediaItem.value?.title, 'Notification Next');
         expect(
@@ -381,7 +398,10 @@ void main() {
         ]);
         await controller.playAt(0);
         expect(handler.mediaItem.value?.title, 'Notification Fail First');
-        await pumpEventQueue(times: 20);
+        await pumpUntil(
+          () => !controller.state.isLoading,
+          reason: 'the first track should settle before the next one fails',
+        );
 
         sourceManager.throwGetAudioStreamOnce(
           const YouTubeApiException(
@@ -391,7 +411,10 @@ void main() {
         );
 
         await controller.next();
-        await pumpEventQueue(times: 10);
+        await pumpUntil(
+          () => handler.mediaItem.value?.title == 'Notification Fail Next',
+          reason: 'the notification should still name the track that failed',
+        );
 
         expect(handler.mediaItem.value?.title, 'Notification Fail Next');
         expect(
@@ -417,7 +440,10 @@ void main() {
 
         firstPlayGate.complete();
         await firstPlay;
-        await pumpEventQueue(times: 5);
+        await pumpUntil(
+          () => audioService.stopCallCount >= 2,
+          reason: 'the superseded first request should stop the backend',
+        );
 
         expect(audioService.stopCallCount, 2);
         expect(controller.state.playingTrack?.sourceId, 'second');
@@ -450,7 +476,10 @@ void main() {
 
         firstPlayGate.complete();
         await firstPlay;
-        await pumpEventQueue(times: 5);
+        await pumpUntil(
+          () => controller.state.playingTrack?.sourceId == 'second-ok',
+          reason: 'the newer request should own the playing track',
+        );
 
         expect(controller.state.playingTrack?.sourceId, 'second-ok');
         expect(controller.state.currentTrack?.sourceId, 'second-ok');
@@ -484,7 +513,13 @@ void main() {
         await audioService.waitForPlayUrlCallCount(2);
 
         final seekFuture = controller.seekTo(const Duration(seconds: 90));
-        await pumpEventQueue(times: 5);
+        // 「seek 還沒送出」等不到，但「交接已經把 playingTrack 換過去」等得到 ——
+        // 先掛在那個里程碑上，缺席的斷言才有意義。
+        await pumpUntil(
+          () => controller.state.playingTrack?.sourceId == 'handoff-next',
+          reason:
+              'the handoff should adopt the next track before the seek lands',
+        );
 
         expect(audioService.seekCalls, isEmpty);
         expect(controller.state.playingTrack?.sourceId, 'handoff-next');
@@ -493,7 +528,10 @@ void main() {
         nextPlayGate.complete();
         await nextFuture;
         await seekFuture;
-        await pumpEventQueue(times: 10);
+        await pumpUntil(
+          () => audioService.seekCalls.isNotEmpty,
+          reason: 'the deferred seek should be applied once the handoff ends',
+        );
 
         expect(audioService.seekCalls, [const Duration(seconds: 90)]);
         expect(controller.state.playingTrack?.sourceId, 'handoff-next');
@@ -513,7 +551,9 @@ void main() {
 
         await controller.next();
         final seekFuture = controller.seekTo(const Duration(seconds: 120));
-        await pumpEventQueue(times: 5);
+        await drainEventQueue(
+          reason: 'the seek must stay deferred inside the 500ms window',
+        );
 
         expect(audioService.seekCalls, isEmpty);
 
@@ -522,7 +562,10 @@ void main() {
               const Duration(milliseconds: 50),
         );
         await seekFuture;
-        await pumpEventQueue(times: 10);
+        await pumpUntil(
+          () => audioService.seekCalls.isNotEmpty,
+          reason: 'the seek should land once the stabilization window passes',
+        );
 
         expect(audioService.seekCalls, [const Duration(seconds: 120)]);
         expect(controller.state.playingTrack?.sourceId, 'stable-next');
@@ -539,7 +582,9 @@ void main() {
       await audioService.waitForPlayUrlCallCount(1);
 
       final seekFuture = controller.seekTo(const Duration(seconds: 75));
-      await pumpEventQueue(times: 5);
+      await drainEventQueue(
+        reason: 'the seek must stay deferred while the first handoff is gated',
+      );
       expect(audioService.seekCalls, isEmpty);
 
       final secondPlay = controller.playTrack(secondTrack);
@@ -547,13 +592,20 @@ void main() {
 
       firstPlayGate.complete();
       await firstPlay;
-      await pumpEventQueue(times: 5);
+      await drainEventQueue(
+        reason: 'the superseded seek must not reach the backend',
+      );
       expect(audioService.seekCalls, isEmpty);
 
       secondPlayGate.complete();
       await secondPlay;
       await seekFuture;
-      await pumpEventQueue(times: 10);
+      await pumpUntil(
+        () =>
+            controller.state.playingTrack?.sourceId == 'fresh-handoff' &&
+            !controller.state.isLoading,
+        reason: 'the newer handoff should settle before the seek is judged',
+      );
 
       expect(audioService.seekCalls, isEmpty);
       expect(controller.state.playingTrack?.sourceId, 'fresh-handoff');
@@ -583,16 +635,24 @@ void main() {
         final secondPlayGate = audioService.enqueuePendingPlayUrl();
 
         final firstPlay = controller.playTrack(firstTrack);
-        await _pumpUntil(() => callbackCount == 1);
+        await pumpUntil(
+          () => callbackCount == 1,
+          reason: 'the first playback-starting callback should fire',
+        );
         expect(controller.state.playingTrack?.sourceId, 'callback-first');
 
         final secondPlay = controller.playTrack(secondTrack);
-        await _pumpUntil(() => callbackCount == 2);
+        await pumpUntil(
+          () => callbackCount == 2,
+          reason: 'the second playback-starting callback should fire',
+        );
         expect(controller.state.playingTrack?.sourceId, 'callback-second');
 
         firstCallback.complete();
         await firstPlay;
-        await pumpEventQueue(times: 5);
+        await drainEventQueue(
+          reason: 'the superseded callback must not stop or replay anything',
+        );
 
         expect(audioService.stopCallCount, 0);
         expect(audioService.playUrlCalls, isEmpty);
@@ -604,7 +664,10 @@ void main() {
         await audioService.waitForPlayUrlCallCount(1);
         secondPlayGate.complete();
         await secondPlay;
-        await pumpEventQueue(times: 5);
+        await pumpUntil(
+          () => audioService.stopCallCount >= 1,
+          reason: 'the newer request should stop the backend exactly once',
+        );
 
         expect(audioService.stopCallCount, 1);
         expect(
@@ -634,7 +697,13 @@ void main() {
         audioService.seekCalls.clear();
 
         await controller.togglePlayPause();
-        await pumpEventQueue(times: 20);
+        await pumpUntil(
+          () =>
+              audioService.playUrlCalls.isNotEmpty &&
+              audioService.seekCalls.isNotEmpty,
+          reason:
+              'an expired url should be re-resolved and the position restored',
+        );
 
         expect(
           audioService.playUrlCalls.single.url,
@@ -667,7 +736,10 @@ void main() {
         audioService.seekCalls.clear();
 
         await controller.togglePlayPause();
-        await pumpEventQueue(times: 10);
+        await pumpUntil(
+          () => controller.state.isPlaying,
+          reason: 'a still-valid url should resume without re-resolving',
+        );
 
         expect(audioService.playUrlCalls, isEmpty);
         expect(audioService.seekCalls, isEmpty);
@@ -696,7 +768,10 @@ void main() {
         );
         await controller.playTrack(newerTrack);
         await oldResume;
-        await pumpEventQueue(times: 20);
+        await pumpUntil(
+          () => controller.state.playingTrack?.sourceId == 'new-after-expired',
+          reason: 'the newer track should survive the stale resume finishing',
+        );
 
         expect(controller.state.playingTrack?.sourceId, 'new-after-expired');
         expect(controller.state.currentTrack?.sourceId, 'new-after-expired');
@@ -734,7 +809,10 @@ void main() {
         audioService.emitNaturalCompletion();
         await audioService.waitForSetUrlCallCount(1);
         await audioService.waitForSeekCallCount(restoreSeekCount);
-        await pumpEventQueue(times: 5);
+        await pumpUntil(
+          () => audioService.stopCallCount >= 3,
+          reason: 'restoring the queue after a temporary play should stop once',
+        );
 
         expect(audioService.stopCallCount, 3);
         expect(controller.state.playingTrack?.sourceId, 'queue-b');
@@ -746,7 +824,9 @@ void main() {
         expect(controller.state.currentTrack?.sourceId, 'newer');
 
         blockedSeek.complete();
-        await pumpEventQueue(times: 20);
+        await drainEventQueue(
+          reason: 'the stale restore seek must not disturb the newer track',
+        );
 
         expect(audioService.stopCallCount, 4);
         expect(controller.state.playingTrack?.sourceId, 'newer');
@@ -785,7 +865,10 @@ void main() {
 
         fallbackPlayGate.complete();
         await firstPlay;
-        await pumpEventQueue(times: 5);
+        await pumpUntil(
+          () => audioService.stopCallCount >= 2,
+          reason: 'the superseded fallback should stop the backend',
+        );
 
         expect(audioService.stopCallCount, 2);
         expect(
@@ -807,7 +890,10 @@ void main() {
 
         secondPlayGate.complete();
         await secondPlay;
-        await pumpEventQueue(times: 5);
+        await pumpUntil(
+          () => !controller.state.isLoading && controller.state.isPlaying,
+          reason: 'the newer fallback request should finish loading',
+        );
 
         expect(audioService.stopCallCount, 2);
         expect(controller.state.playingTrack?.sourceId, 'second-fallback');
@@ -829,7 +915,10 @@ void main() {
       );
 
       await controller.playTrack(_track('locked-song', title: 'Locked Song'));
-      await pumpEventQueue(times: 5);
+      await pumpUntil(
+        () => toasts.isNotEmpty,
+        reason: 'the skipped source error should reach the user',
+      );
 
       expect(toasts, isNotEmpty);
       expect(toasts.last.message, contains('Locked Song'));
@@ -849,7 +938,10 @@ void main() {
       );
 
       await controller.playTrack(_track('geo-song', title: 'Geo Song'));
-      await pumpEventQueue(times: 5);
+      await pumpUntil(
+        () => toasts.isNotEmpty,
+        reason: 'the geo restriction should reach the user',
+      );
 
       expect(toasts, isNotEmpty);
       expect(toasts.last.message, contains('Geo Song'));
@@ -862,7 +954,10 @@ void main() {
 
     test('source skip errors clear stale stream metadata', () async {
       await controller.playTrack(_track('playable-song', title: 'Playable'));
-      await pumpEventQueue(times: 5);
+      await pumpUntil(
+        () => controller.state.currentContainer == 'm4a',
+        reason: 'the playable track should publish its stream metadata',
+      );
 
       expect(controller.state.currentContainer, 'm4a');
       expect(controller.state.currentCodec, 'aac');
@@ -876,7 +971,10 @@ void main() {
       );
 
       await controller.playTrack(_track('blocked-song', title: 'Blocked Song'));
-      await pumpEventQueue(times: 5);
+      await pumpUntil(
+        () => controller.state.error != null,
+        reason: 'the blocked track should surface an error',
+      );
 
       expect(controller.state.playingTrack?.sourceId, 'blocked-song');
       expect(controller.state.error, contains('Blocked Song'));
@@ -898,7 +996,10 @@ void main() {
       );
 
       await controller.playTrack(_track('flag-song', title: 'Flag Song'));
-      await pumpEventQueue(times: 5);
+      await pumpUntil(
+        () => toasts.isNotEmpty,
+        reason: 'the copyright error should reach the user',
+      );
 
       expect(toasts, isNotEmpty);
       expect(toasts.last.message, contains('Flag Song'));
@@ -923,7 +1024,10 @@ void main() {
         await controller.playTrack(
           _track('private-bilibili-video', title: 'Private Bilibili Video'),
         );
-        await pumpEventQueue(times: 5);
+        await pumpUntil(
+          () => toasts.isNotEmpty,
+          reason: 'the private-video error should reach the user',
+        );
 
         expect(toasts, isNotEmpty);
         expect(toasts.last.message, isNot(contains('62012')));
@@ -942,14 +1046,20 @@ void main() {
     // 計時器每秒都會再判定一次「播完」—— Android 實測會無限重複觸發 82 次。
     test('reaching the end of the queue stops reporting playback', () async {
       await controller.playAll([_track('last-track', title: 'Last Track')]);
-      await pumpEventQueue(times: 10);
+      await pumpUntil(
+        () => controller.state.isPlaying,
+        reason: 'the last track should be playing before it is completed',
+      );
 
       audioService.setDurationValue(const Duration(minutes: 3));
       audioService.emitPosition(const Duration(minutes: 3));
       final pausesBefore = audioService.pauseCallCount;
 
       audioService.emitNaturalCompletion();
-      await pumpEventQueue(times: 20);
+      await pumpUntil(
+        () => audioService.pauseCallCount > pausesBefore,
+        reason: 'the end of the queue should pause the backend',
+      );
 
       expect(audioService.pauseCallCount, greaterThan(pausesBefore));
       expect(audioService.isPlaying, isFalse);
@@ -976,7 +1086,10 @@ void main() {
       audioService.emitOutputDeviceFailure(
         'Could not open/initialize audio device -> no sound.',
       );
-      await pumpEventQueue(times: 10);
+      await pumpUntil(
+        () => toasts.isNotEmpty,
+        reason: 'the output device failure should reach the toast stream',
+      );
 
       expect(toasts, isNotEmpty);
       expect(toasts.last.type, ToastType.error);
@@ -995,8 +1108,10 @@ void main() {
 
       playGate.complete();
       await playFuture;
-      await Future<void>.delayed(const Duration(milliseconds: 600));
-      await pumpEventQueue(times: 5);
+      await pumpUntil(
+        () => audioService.pauseCallCount > 0,
+        reason: 'the device failure should stop reporting playback',
+      );
 
       expect(audioService.pauseCallCount, greaterThan(0));
     });
@@ -1014,7 +1129,12 @@ void main() {
       audioService.emitOutputDeviceFailure(
         'Could not open/initialize audio device -> no sound.',
       );
-      await pumpEventQueue(times: 10);
+      // 這條就是 issue #43 在 CI 上抓到的失敗（run 34121005229）：toast 要從
+      // endReasons 一路走到 messageStream，10 圈事件迴圈在滿載時換不到那段路。
+      await pumpUntil(
+        () => toasts.isNotEmpty,
+        reason: 'the output device failure should reach the user during radio',
+      );
 
       expect(toasts, isNotEmpty);
       expect(toasts.last.type, ToastType.error);
@@ -1039,7 +1159,9 @@ void main() {
 
       audioService.emitTransportFailure('tcp: connection reset');
       audioService.emitMediaOpenError('Failed to open https://example.com');
-      await pumpEventQueue(times: 10);
+      await drainEventQueue(
+        reason: 'radio must swallow transport and media-open errors',
+      );
 
       expect(toasts, isEmpty);
     });
@@ -1069,7 +1191,9 @@ void main() {
 
       playGate.complete();
       await playFuture;
-      await pumpEventQueue(times: 5);
+      await drainEventQueue(
+        reason: 'the aborted request must not revive the playback state',
+      );
 
       expect(controller.state.isLoading, isFalse);
       expect(controller.state.isPlaying, isFalse);
@@ -1087,7 +1211,10 @@ void main() {
         await controller.playTrack(
           _track('media-open-post-handoff', title: 'Media Open Post Handoff'),
         );
-        await pumpEventQueue(times: 5);
+        await pumpUntil(
+          () => !controller.state.isLoading,
+          reason: 'the initial play should finish loading',
+        );
 
         expect(controller.state.isLoading, isFalse);
         expect(controller.state.error, isNull);
@@ -1098,8 +1225,12 @@ void main() {
         audioService.emitMediaOpenError(
           'Failed to open https://example.com/media-open-post-handoff.m4a.',
         );
-        await Future<void>.delayed(const Duration(milliseconds: 2200));
-        await pumpEventQueue(times: 5);
+        // 錯誤要等後端自己的 2 秒判定窗過去才變成 terminal，所以預算放寬到 10 秒。
+        await pumpUntil(
+          () => toasts.isNotEmpty,
+          reason: 'the post-handoff media open error should become terminal',
+          timeout: const Duration(seconds: 10),
+        );
 
         expect(toasts, isNotEmpty);
         expect(toasts.last.type, ToastType.error);
@@ -1119,7 +1250,10 @@ void main() {
       await controller.playTrack(
         _track('media-open-old-pending', title: 'Media Open Old Pending'),
       );
-      await pumpEventQueue(times: 5);
+      await pumpUntil(
+        () => controller.state.isPlaying,
+        reason: 'the first track should be playing before the error is raised',
+      );
 
       audioService.setPlayingValue(false);
       audioService.setPositionValue(Duration.zero);
@@ -1131,11 +1265,18 @@ void main() {
       await controller.playTrack(
         _track('media-open-new-track', title: 'Media Open New Track'),
       );
-      await pumpEventQueue(times: 5);
+      await pumpUntil(
+        () => controller.state.isPlaying,
+        reason:
+            'the new playback should settle before the stop count is sampled',
+      );
       final stopCountAfterNewPlayback = audioService.stopCallCount;
 
+      // 舊的延後 stop 排在 2 秒後；睡過那個時點才有資格說它沒有觸發。
       await Future<void>.delayed(const Duration(milliseconds: 1800));
-      await pumpEventQueue(times: 5);
+      await drainEventQueue(
+        reason: 'the cancelled post-handoff stop must never fire',
+      );
 
       expect(
         toasts.map((toast) => toast.message),
@@ -1162,14 +1303,20 @@ void main() {
       );
 
       playGate.complete();
-      await pumpEventQueue(times: 5);
+      await drainEventQueue(
+        reason:
+            'the play request must stay open until the error turns terminal',
+      );
 
       expect(playCompleted, isFalse);
       expect(controller.state.isLoading, isTrue);
 
-      await Future<void>.delayed(const Duration(milliseconds: 2200));
       await playFuture;
-      await pumpEventQueue(times: 5);
+      await pumpUntil(
+        () => playCompleted,
+        reason: 'the play request should complete once the error is terminal',
+        timeout: const Duration(seconds: 10),
+      );
 
       expect(playCompleted, isTrue);
       expect(controller.state.error, contains('Media Open Active'));
@@ -1191,7 +1338,11 @@ void main() {
       await Future<void>.delayed(const Duration(milliseconds: 2200));
       playGate.complete();
       await playFuture;
-      await pumpEventQueue(times: 5);
+      await pumpUntil(
+        () => controller.state.error != null,
+        reason: 'the stale media open error should surface',
+        timeout: const Duration(seconds: 10),
+      );
 
       expect(controller.state.error, contains('Media Open Stale Loading'));
       expect(controller.state.isLoading, isFalse);
@@ -1199,7 +1350,9 @@ void main() {
 
       audioService.setPlayingValue(false);
       audioService.emitProcessingState(FmpAudioProcessingState.loading);
-      await pumpEventQueue(times: 5);
+      await drainEventQueue(
+        reason: 'a late loading state must not reopen the terminal error',
+      );
 
       expect(controller.state.error, contains('Media Open Stale Loading'));
       expect(controller.state.isLoading, isFalse);
@@ -1226,13 +1379,18 @@ void main() {
         await Future<void>.delayed(const Duration(milliseconds: 2200));
 
         playGate.complete();
-        await pumpEventQueue(times: 5);
+        await drainEventQueue(
+          reason: 'the request must stay open while the stop is still gated',
+        );
 
         expect(playCompleted, isFalse);
 
         stopGate.complete();
         await playFuture;
-        await pumpEventQueue(times: 5);
+        await pumpUntil(
+          () => playCompleted,
+          reason: 'the request should complete once the stop is released',
+        );
 
         expect(playCompleted, isTrue);
         expect(controller.state.isLoading, isFalse);
@@ -1254,12 +1412,18 @@ void main() {
         await audioService.waitForPlayUrlCallCount(1);
 
         final terminalStopGate = audioService.enqueuePendingStop();
+        final stopsBeforeTerminal = audioService.stopCallCount;
         audioService.emitMediaOpenError(
           'Failed to open https://example.com/media-open-old-active.m4a.',
         );
         oldPlayGate.complete();
-        await Future<void>.delayed(const Duration(milliseconds: 2200));
-        await pumpEventQueue(times: 5);
+        // 錯誤要 2 秒才轉成 terminal，而它轉成 terminal 的可觀察後果就是這個 stop。
+        await pumpUntil(
+          () => audioService.stopCallCount > stopsBeforeTerminal,
+          reason:
+              'the terminal media open error should ask the backend to stop',
+          timeout: const Duration(seconds: 10),
+        );
 
         final newPlayGate = audioService.enqueuePendingPlayUrl();
         final newPlayFuture = controller.playTrack(
@@ -1269,11 +1433,19 @@ void main() {
 
         terminalStopGate.complete();
         await oldPlayFuture;
-        await pumpEventQueue(times: 5);
+        await drainEventQueue(
+          reason: 'let the superseded terminal path finish unwinding',
+        );
 
         newPlayGate.complete();
         await newPlayFuture;
-        await pumpEventQueue(times: 5);
+        await pumpUntil(
+          () =>
+              controller.state.isPlaying &&
+              controller.state.currentTrack?.sourceId ==
+                  'media-open-new-active',
+          reason: 'the newer request should own the state once it finishes',
+        );
 
         expect(
           toasts.map((toast) => toast.message),
@@ -1301,11 +1473,17 @@ void main() {
       await controller.playTrack(
         _track('retry-media-open-terminal', title: 'Retry Media Open Terminal'),
       );
-      await pumpEventQueue(times: 10);
+      await pumpUntil(
+        () => controller.state.isPlaying,
+        reason: 'the track should be playing before the transport fails',
+      );
 
       audioService.emitPosition(const Duration(seconds: 19));
       audioService.emitTransportFailure('network timeout during playback');
-      await pumpEventQueue(times: 10);
+      await pumpUntil(
+        () => controller.state.isRetrying,
+        reason: 'a transport failure mid-playback should start a retry',
+      );
 
       expect(controller.state.isRetrying, isTrue);
       expect(controller.state.isNetworkError, isTrue);
@@ -1321,7 +1499,11 @@ void main() {
       await Future<void>.delayed(const Duration(milliseconds: 2200));
       retryPlayGate.complete();
       await retry;
-      await pumpEventQueue(times: 5);
+      await pumpUntil(
+        () => toasts.isNotEmpty,
+        reason: 'the terminal error during a retry should reach the user',
+        timeout: const Duration(seconds: 10),
+      );
 
       expect(toasts, isNotEmpty);
       expect(toasts.last.type, ToastType.error);
@@ -1349,7 +1531,10 @@ void main() {
         await controller.playTrack(
           _track('rate-limited-song', title: 'Rate Limited Song'),
         );
-        await pumpEventQueue(times: 10);
+        await pumpUntil(
+          () => controller.state.error != null,
+          reason: 'a rate-limited source should surface its own message',
+        );
 
         expect(controller.state.isLoading, isFalse);
         expect(controller.state.isRetrying, isFalse);
@@ -1373,7 +1558,10 @@ void main() {
           _track('locked-queue-song', title: 'Locked Queue Song'),
           _track('next-after-locked', title: 'Next After Locked'),
         ]);
-        await pumpEventQueue(times: 5);
+        await pumpUntil(
+          () => toasts.isNotEmpty,
+          reason: 'skipping a locked queue track should warn the user',
+        );
 
         expect(toasts, isNotEmpty);
         expect(toasts.last.message, contains('Locked Queue Song'));
@@ -1381,7 +1569,9 @@ void main() {
         expect(toasts.last.type, ToastType.warning);
       } finally {
         await Future<void>.delayed(const Duration(milliseconds: 350));
-        await pumpEventQueue(times: 5);
+        await drainEventQueue(
+          reason: 'let the queue skip settle before the fixture tears down',
+        );
       }
     });
 
@@ -1405,14 +1595,23 @@ void main() {
         final firstPlay = controller.playTrack(firstTrack);
         // 等到第一個請求真的走進串流解析，而不是猜「一圈事件迴圈應該夠」——
         // 圈數在滿載的機器上不夠，那正是 issue #43 的其中一條根因。
-        await _pumpUntil(
+        await pumpUntil(
           () => sourceManager.getAudioStreamCallCount > resolvedBefore,
+          reason: 'the first request should reach stream resolution',
         );
 
         final secondPlay = controller.playTrack(secondTrack);
         await audioService.waitForPlayUrlCallCount(1);
         await firstPlay;
-        await pumpEventQueue(times: 5);
+        // 這是 issue #43 標題那條測試在 CI 上實際掛掉的地方：作廢的第一個請求
+        // 結束之後，狀態要換手給第二個請求，而那不是固定圈數換得到的。
+        await pumpUntil(
+          () =>
+              controller.state.playingTrack?.sourceId == 'fresh-after-error' &&
+              controller.state.isLoading,
+          reason:
+              'the newer request should own the state after the stale error',
+        );
 
         expect(audioService.stopCallCount, 2);
         expect(controller.state.playingTrack?.sourceId, 'fresh-after-error');
@@ -1422,7 +1621,10 @@ void main() {
 
         secondPlayGate.complete();
         await secondPlay;
-        await pumpEventQueue(times: 5);
+        await pumpUntil(
+          () => !controller.state.isLoading && controller.state.isPlaying,
+          reason: 'the newer request should finish loading',
+        );
 
         expect(audioService.stopCallCount, 2);
         expect(controller.state.playingTrack?.sourceId, 'fresh-after-error');
@@ -1454,7 +1656,10 @@ void main() {
         );
         await restoreSetUrl;
         await restoreSeek;
-        await pumpEventQueue(times: 10);
+        await pumpUntil(
+          () => controller.state.currentTrack?.sourceId == 'radio-b',
+          reason: 'returning from radio should restore the saved queue entry',
+        );
 
         expect(controller.state.currentTrack?.sourceId, 'radio-b');
         expect(controller.state.playingTrack?.sourceId, 'radio-b');
@@ -1486,7 +1691,17 @@ void main() {
 
         audioService.emitNaturalCompletion();
         await restoreSetUrl;
-        await pumpEventQueue(times: 20);
+        // 條件必須是「進入時還不成立」的東西，否則 pumpUntil 立刻返回、一圈都沒推。
+        // 這裡 sourceId 從頭到尾都是 restore-b，真正會變的是佇列換上的**新實例**。
+        await pumpUntil(
+          () =>
+              !identical(
+                controller.queueState.queueTrack,
+                queueTrackBeforeTemporary,
+              ) &&
+              controller.state.playingTrack?.sourceId == 'restore-b',
+          reason: 'the queue should be restored with a fresh track instance',
+        );
 
         final queueTrackAfterRestore = controller.queueState.queueTrack;
         final playingTrackAfterRestore = controller.state.playingTrack;
@@ -1517,17 +1732,27 @@ void main() {
           tracks: mixTracks,
           startIndex: 1,
         );
-        await pumpEventQueue(times: 5);
+        await pumpUntil(
+          () =>
+              controller.queueState.isMixMode &&
+              controller.queueState.isLoadingMoreMix,
+          reason: 'the mix should enter load-more before the queue is cleared',
+        );
 
         expect(controller.queueState.isMixMode, isTrue);
         expect(controller.queueState.mixTitle, 'My Mix');
         expect(controller.queueState.isLoadingMoreMix, isTrue);
 
         await controller.clearQueue();
-        await pumpEventQueue(times: 5);
+        await pumpUntil(
+          () => !controller.queueState.isMixMode,
+          reason: 'clearing the queue should leave mix mode',
+        );
 
         loadMoreGate.complete();
-        await pumpEventQueue(times: 20);
+        await drainEventQueue(
+          reason: 'the stale load-more must not revive mix mode',
+        );
 
         final persistedQueue = await queueRepository.getOrCreate();
 
@@ -1564,7 +1789,12 @@ void main() {
           tracks: oldMixTracks,
           startIndex: 1,
         );
-        await pumpEventQueue(times: 5);
+        await pumpUntil(
+          () =>
+              controller.queueState.mixTitle == 'Old Mix' &&
+              controller.queueState.isLoadingMoreMix,
+          reason: 'the old mix should be loading more before it is replaced',
+        );
 
         expect(controller.queueState.mixTitle, 'Old Mix');
         expect(controller.queueState.isLoadingMoreMix, isTrue);
@@ -1576,7 +1806,12 @@ void main() {
           tracks: newMixTracks,
           startIndex: 0,
         );
-        await pumpEventQueue(times: 5);
+        await pumpUntil(
+          () =>
+              controller.queueState.mixTitle == 'New Mix' &&
+              controller.state.currentTrack?.sourceId == 'new-mix-a',
+          reason: 'the newer mix should take over the queue',
+        );
 
         expect(controller.queueState.isMixMode, isTrue);
         expect(controller.queueState.mixTitle, 'New Mix');
@@ -1585,7 +1820,9 @@ void main() {
         expect(controller.queueState.isLoadingMoreMix, isFalse);
 
         oldLoadMoreGate.complete();
-        await pumpEventQueue(times: 20);
+        await drainEventQueue(
+          reason: 'the old mix load-more must not overwrite the newer mix',
+        );
 
         expect(controller.queueState.isMixMode, isTrue);
         expect(controller.queueState.mixTitle, 'New Mix');
@@ -1624,13 +1861,18 @@ void main() {
         await controller.initialize();
 
         await controller.playSingle(_track('starved', title: 'Starved'));
-        await pumpEventQueue(times: 10);
+        await pumpUntil(
+          () => controller.state.playingTrack?.sourceId == 'starved',
+          reason: 'the track should be playing before buffering starves',
+        );
 
         final playsBeforeStarvation = audioService.playUrlCalls.length;
         audioService.setPlayingValue(true);
         audioService.emitProcessingState(FmpAudioProcessingState.buffering);
-        await Future<void>.delayed(const Duration(milliseconds: 60));
-        await pumpEventQueue(times: 20);
+        await pumpUntil(
+          () => audioService.playUrlCalls.length > playsBeforeStarvation,
+          reason: 'the 30ms starvation budget should trigger one recovery',
+        );
 
         // 只救一次，而且救的方式是重發一次請求（內含 _execute 的 fallback 一次）。
         expect(
@@ -1657,7 +1899,13 @@ void main() {
       ];
 
       await controller.playAll(tracks, startIndex: 0);
-      await pumpEventQueue(times: 20);
+      await pumpUntil(
+        () =>
+            controller.queueState.queue.length == 2 &&
+            controller.queueState.queue[1].audioUrl ==
+                'https://example.com/prefetch-play-next.m4a',
+        reason: 'playback should prefetch the next track into the queue',
+      );
 
       expect(controller.queueState.queue.length, 2);
       final nextQueueTrack = controller.queueState.queue[1];
@@ -1682,7 +1930,15 @@ void main() {
         ];
 
         await controller.playAll(tracks, startIndex: 0);
-        await pumpEventQueue(times: 20);
+        // 預取是 fire-and-forget，沒有人等它 —— 20 圈事件迴圈在滿載的機器上換不到
+        // 它完成，這是本輪壓力跑（20 次 2 紅）實際抓到的第三條抖動。
+        await pumpUntil(
+          () =>
+              controller.queueState.queue.length == 2 &&
+              controller.queueState.queue[1].audioUrl ==
+                  'https://example.com/prefetch-next.m4a',
+          reason: 'playback should prefetch the next track into the queue',
+        );
 
         // 第一次播放就已經把下一首預取好了（見上一條測試）。這裡要驗的是
         // 「重啟之後的佇列恢復也會預取」，而它的起點是資料庫裡那個過期的 URL。
@@ -1727,7 +1983,13 @@ void main() {
           mixTracksFetcher: mixTracksFetcher.call,
         );
         await controller.initialize();
-        await pumpEventQueue(times: 20);
+        await pumpUntil(
+          () =>
+              controller.queueState.queue.length == 2 &&
+              controller.queueState.queue[1].audioUrl ==
+                  'https://example.com/prefetch-next.m4a',
+          reason: 'restoring the queue should prefetch the next track too',
+        );
 
         expect(controller.queueState.queue.length, 2);
         final nextTrackAfterPrepare = controller.queueState.queue[1];
@@ -1756,7 +2018,12 @@ void main() {
         final track = _track('runtime-boundary', title: 'Runtime Boundary');
 
         await controller.playSingle(track);
-        await pumpEventQueue(times: 20);
+        await pumpUntil(
+          () =>
+              controller.queueState.queueTrack?.audioUrl ==
+              'https://example.com/runtime-boundary.m4a',
+          reason: 'the resolved url should land on the queue instance',
+        );
 
         final queueTrackAfterPlay = controller.queueState.queueTrack;
         final playingTrackAfterPlay = controller.state.playingTrack;
@@ -1789,7 +2056,12 @@ void main() {
           ..audioUrlExpiry = DateTime.utc(2031, 1, 1);
         queueManager.replaceTrack(replacement);
         await replacementNotified.future;
-        await pumpEventQueue(times: 5);
+        await pumpUntil(
+          () =>
+              controller.queueState.queueTrack?.audioUrl ==
+              'https://manual.example/runtime-boundary.m4a',
+          reason: 'the explicit replacement should reach the queue state',
+        );
         await queueSub.cancel();
 
         expect(
@@ -1831,7 +2103,9 @@ void main() {
 
       queueManager.dispose();
       queueManager.setCurrentIndex(1);
-      await pumpEventQueue(times: 5);
+      await drainEventQueue(
+        reason: 'a disposed queue manager must not emit state',
+      );
 
       expect(stateEvents, isEmpty);
       await subscription.cancel();
@@ -1948,14 +2222,6 @@ class _PendingLyricsMatch {
   final bool result;
 }
 
-Future<void> _pumpUntil(bool Function() condition, {int maxPumps = 50}) async {
-  for (var i = 0; i < maxPumps; i++) {
-    if (condition()) return;
-    await pumpEventQueue();
-  }
-  throw StateError('Condition was not met after $maxPumps event pumps');
-}
-
 class _PassThroughTitleParser implements TitleParser {
   @override
   ParsedTitle parse(String title, {String? uploader}) {
@@ -2009,7 +2275,7 @@ class _FakeSource implements AudioStreamSource {
   Object? _alwaysGetAudioStreamError;
   Duration? nextAudioExpiry;
 
-  /// 已經被要求解析串流幾次。單調遞增，所以 `_pumpUntil` 不會錯過某個瞬間。
+  /// 已經被要求解析串流幾次。單調遞增，所以 `pumpUntil` 不會錯過某個瞬間。
   int getAudioStreamCallCount = 0;
 
   void throwGetAudioStreamOnce(Object error) {

--- a/test/services/audio/audio_controller_phase1_test.dart
+++ b/test/services/audio/audio_controller_phase1_test.dart
@@ -38,8 +38,8 @@ import 'package:fmp/services/audio/stream_resolution_service.dart';
 import 'package:isar_community/isar.dart';
 
 import '../../support/audio_controller_harness.dart';
-import '../../support/fakes/fake_audio_service.dart';
 import '../../support/fakes/count_waiters.dart';
+import '../../support/fakes/fake_audio_service.dart';
 import '../../support/fakes/fake_source_auth_context.dart';
 import '../../support/isar_test_harness.dart';
 import '../../support/now_playing.dart';

--- a/test/services/audio/audio_controller_phase1_test.dart
+++ b/test/services/audio/audio_controller_phase1_test.dart
@@ -39,6 +39,7 @@ import 'package:isar_community/isar.dart';
 
 import '../../support/audio_controller_harness.dart';
 import '../../support/fakes/fake_audio_service.dart';
+import '../../support/fakes/count_waiters.dart';
 import '../../support/fakes/fake_source_auth_context.dart';
 import '../../support/isar_test_harness.dart';
 import '../../support/now_playing.dart';
@@ -2179,7 +2180,7 @@ class _GateableLyricsAutoMatchService extends LyricsAutoMatchService {
   final List<_PendingLyricsMatch> _pending = [];
   final List<Track> calls = [];
   final List<List<String>?> enabledSourceCalls = [];
-  final List<_CountWaiter> _waiters = [];
+  late final _waiters = CountWaiters(() => calls.length);
 
   Completer<void> enqueuePendingResult(bool result) {
     final completer = Completer<void>();
@@ -2187,12 +2188,7 @@ class _GateableLyricsAutoMatchService extends LyricsAutoMatchService {
     return completer;
   }
 
-  Future<void> waitForCallCount(int count) {
-    if (calls.length >= count) return Future.value();
-    final completer = Completer<void>();
-    _waiters.add(_CountWaiter(count, completer));
-    return completer.future;
-  }
+  Future<void> waitForCallCount(int count) => _waiters.waitFor(count);
 
   @override
   Future<bool> tryAutoMatch(
@@ -2202,12 +2198,7 @@ class _GateableLyricsAutoMatchService extends LyricsAutoMatchService {
   }) async {
     calls.add(track);
     enabledSourceCalls.add(enabledSources);
-    for (final waiter in List<_CountWaiter>.from(_waiters)) {
-      if (calls.length >= waiter.target && !waiter.completer.isCompleted) {
-        waiter.completer.complete();
-        _waiters.remove(waiter);
-      }
-    }
+    _waiters.notify();
     if (_pending.isEmpty) return false;
     final pending = _pending.removeAt(0);
     await pending.completer.future;
@@ -2231,13 +2222,6 @@ class _PassThroughTitleParser implements TitleParser {
       cleanedTitle: title,
     );
   }
-}
-
-class _CountWaiter {
-  _CountWaiter(this.target, this.completer);
-
-  final int target;
-  final Completer<void> completer;
 }
 
 class _TestMixTracksFetcher {

--- a/test/services/audio/audio_device_preference_test.dart
+++ b/test/services/audio/audio_device_preference_test.dart
@@ -25,6 +25,7 @@ import '../../support/fakes/fake_audio_service.dart';
 import '../../support/fakes/fake_source_auth_context.dart';
 import '../../support/isar_test_harness.dart';
 import '../../support/now_playing.dart';
+import '../../support/pump_until.dart';
 
 /// 桌面輸出裝置的記憶（issue #42）。
 ///
@@ -136,7 +137,10 @@ void main() {
       });
 
       audioService.emitAudioDevices([speakers, headphones]);
-      await pumpEventQueue();
+      await pumpUntil(
+        () => audioService.audioDevice != null,
+        reason: 'the stored preference should be reapplied',
+      );
 
       expect(audioService.audioDevice?.name, headphones.name);
     });
@@ -150,7 +154,9 @@ void main() {
         });
 
         audioService.emitAudioDevices([speakers]);
-        await pumpEventQueue();
+        await drainEventQueue(
+          reason: 'a missing preferred device must not switch the output',
+        );
 
         // 沒有切走，也沒有把設定清掉 —— 使用者把耳機插回來時還會想要它。
         expect(audioService.audioDevice, isNull);
@@ -168,13 +174,19 @@ void main() {
         });
 
         audioService.emitAudioDevices([speakers, headphones]);
-        await pumpEventQueue();
+        await pumpUntil(
+          () => audioService.audioDevice != null,
+          reason: 'the stored preference should be reapplied',
+        );
         expect(audioService.audioDevice?.name, headphones.name);
 
         await controller.setAudioDevice(speakers);
         // 插拔會讓裝置清單反覆重送，那不該把使用者剛選的蓋回去。
         audioService.emitAudioDevices([speakers, headphones]);
-        await pumpEventQueue();
+        await pumpUntil(
+          () => audioService.audioDevice?.name == speakers.name,
+          reason: 'a device list resend must not undo the user choice',
+        );
 
         expect(audioService.audioDevice?.name, speakers.name);
       },
@@ -182,7 +194,9 @@ void main() {
 
     test('no stored device means the output is left untouched', () async {
       audioService.emitAudioDevices([speakers, headphones]);
-      await pumpEventQueue();
+      await drainEventQueue(
+        reason: 'with no stored device the output must be left alone',
+      );
 
       expect(audioService.audioDevice, isNull);
     });

--- a/test/services/audio/audio_queue_state_provider_test.dart
+++ b/test/services/audio/audio_queue_state_provider_test.dart
@@ -30,6 +30,7 @@ import '../../support/fakes/fake_audio_service.dart';
 import '../../support/fakes/fake_source_auth_context.dart';
 import '../../support/isar_test_harness.dart';
 import '../../support/now_playing.dart';
+import '../../support/pump_until.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -137,7 +138,10 @@ void main() {
               tracks: [_track('mix-a'), _track('mix-b')],
               startIndex: 1,
             );
-        await pumpEventQueue(times: 5);
+        await pumpUntil(
+          () => harness.container.read(queueStateProvider).isMixMode,
+          reason: 'the mix session should reach the queue state provider',
+        );
 
         expect(harness.container.read(queueStateProvider).isMixMode, isTrue);
         expect(harness.container.read(queueStateProvider).mixTitle, 'My Mix');

--- a/test/services/audio/audio_queue_state_provider_test.dart
+++ b/test/services/audio/audio_queue_state_provider_test.dart
@@ -151,8 +151,9 @@ void main() {
         );
 
         loadMoreGate.complete();
-        await _waitUntil(
+        await pumpUntil(
           () => !harness.container.read(queueStateProvider).isLoadingMoreMix,
+          reason: 'the mix load-more should finish once its gate opens',
         );
 
         expect(harness.container.read(queueStateProvider).isMixMode, isTrue);
@@ -170,19 +171,6 @@ Track _track(String sourceId) => Track()
   ..sourceId = sourceId
   ..sourceType = SourceIds.youtube
   ..title = sourceId;
-
-Future<void> _waitUntil(
-  bool Function() condition, {
-  Duration timeout = const Duration(seconds: 5),
-}) async {
-  final deadline = DateTime.now().add(timeout);
-  while (!condition()) {
-    if (DateTime.now().isAfter(deadline)) {
-      throw TimeoutException('Timed out waiting for condition');
-    }
-    await Future<void>.delayed(const Duration(milliseconds: 10));
-  }
-}
 
 class _AudioControllerHarness {
   _AudioControllerHarness({

--- a/test/services/audio/audio_service_dispose_test.dart
+++ b/test/services/audio/audio_service_dispose_test.dart
@@ -38,6 +38,7 @@ import '../../support/fakes/fake_audio_service.dart';
 import '../../support/fakes/fake_source_auth_context.dart';
 import '../../support/isar_test_harness.dart';
 import '../../support/now_playing.dart';
+import '../../support/pump_until.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -95,7 +96,9 @@ void main() {
 
         final controller = container.read(audioControllerProvider.notifier);
         await controller.initialize();
-        await pumpEventQueue(times: 5);
+        await drainEventQueue(
+          reason: 'let initialization settle before the container is disposed',
+        );
 
         expect(container.dispose, returnsNormally);
         await Future<void>.delayed(Duration.zero);
@@ -190,10 +193,14 @@ void main() {
         try {
           final controller = container.read(audioControllerProvider.notifier);
           await controller.initialize();
-          await pumpEventQueue(times: 5);
+          await drainEventQueue(
+            reason: 'let initialization settle before the setting changes',
+          );
 
           container.read(plainLyricsSettingProvider.notifier).set(true);
-          await pumpEventQueue(times: 10);
+          await drainEventQueue(
+            reason: 'an unrelated setting must not rebuild the controller',
+          );
 
           expect(
             container.read(audioControllerProvider.notifier),

--- a/test/services/audio/lyrics_auto_match_coordinator_test.dart
+++ b/test/services/audio/lyrics_auto_match_coordinator_test.dart
@@ -17,6 +17,7 @@ import 'package:fmp/services/lyrics/qqmusic_source.dart';
 import 'package:fmp/services/lyrics/title_parser.dart';
 import 'package:isar_community/isar.dart';
 
+import '../../support/fakes/count_waiters.dart';
 import '../../support/isar_test_harness.dart';
 
 /// `LyricsAutoMatchCoordinator` 是 Phase 4 步驟 D 從 `AudioController` 抽出來的
@@ -163,7 +164,7 @@ class _RecordingLyricsAutoMatchService extends LyricsAutoMatchService {
   final List<Track> calls = [];
   final List<List<String>?> enabledSourceCalls = [];
   final List<Completer<void>> _pending = [];
-  final List<_CountWaiter> _waiters = [];
+  late final _waiters = CountWaiters(() => calls.length);
 
   Completer<void> enqueuePending() {
     final completer = Completer<void>();
@@ -171,12 +172,7 @@ class _RecordingLyricsAutoMatchService extends LyricsAutoMatchService {
     return completer;
   }
 
-  Future<void> waitForCallCount(int count) {
-    if (calls.length >= count) return Future.value();
-    final completer = Completer<void>();
-    _waiters.add(_CountWaiter(count, completer));
-    return completer.future;
-  }
+  Future<void> waitForCallCount(int count) => _waiters.waitFor(count);
 
   @override
   Future<bool> tryAutoMatch(
@@ -186,12 +182,7 @@ class _RecordingLyricsAutoMatchService extends LyricsAutoMatchService {
   }) async {
     calls.add(track);
     enabledSourceCalls.add(enabledSources);
-    for (final waiter in List<_CountWaiter>.from(_waiters)) {
-      if (calls.length >= waiter.target && !waiter.completer.isCompleted) {
-        waiter.completer.complete();
-        _waiters.remove(waiter);
-      }
-    }
+    _waiters.notify();
     if (_pending.isEmpty) return false;
     await _pending.removeAt(0).future;
     return true;
@@ -207,12 +198,6 @@ class _PassThroughTitleParser implements TitleParser {
       cleanedTitle: title,
     );
   }
-}
-
-class _CountWaiter {
-  _CountWaiter(this.target, this.completer);
-  final int target;
-  final Completer<void> completer;
 }
 
 Track _track(String sourceId) => Track()

--- a/test/services/audio/lyrics_auto_match_coordinator_test.dart
+++ b/test/services/audio/lyrics_auto_match_coordinator_test.dart
@@ -19,6 +19,7 @@ import 'package:isar_community/isar.dart';
 
 import '../../support/fakes/count_waiters.dart';
 import '../../support/isar_test_harness.dart';
+import '../../support/pump_until.dart';
 
 /// `LyricsAutoMatchCoordinator` 是 Phase 4 步驟 D 從 `AudioController` 抽出來的
 /// 第二個副作用協作者。
@@ -79,7 +80,9 @@ void main() {
       final coordinator = build();
 
       coordinator.onTrackStarted(_track('a'));
-      await pumpEventQueue();
+      await drainEventQueue(
+        reason: 'the setting being off must reach no service call',
+      );
 
       expect(service.calls, isEmpty);
     });
@@ -112,11 +115,16 @@ void main() {
 
       // 舊的先回來。它不可以把「正在比對」關掉 —— 新的還在跑。
       firstGate.complete();
-      await pumpEventQueue();
+      await drainEventQueue(
+        reason: 'the stale match must not clear the in-progress flag',
+      );
       expect(states.last, isTrue);
 
       secondGate.complete();
-      await pumpEventQueue();
+      await pumpUntil(
+        () => !states.last,
+        reason: 'the newer match finishing should clear the flag',
+      );
       expect(states.last, isFalse);
     });
 
@@ -132,7 +140,9 @@ void main() {
 
       coordinator.dispose();
       gate.complete();
-      await pumpEventQueue();
+      await drainEventQueue(
+        reason: 'a match returning after dispose must not touch the UI',
+      );
 
       // dispose 之後那次比對回來，不能再碰已經沒人在聽的 UI。
       expect(states, [true]);
@@ -142,7 +152,9 @@ void main() {
       final coordinator = LyricsAutoMatchCoordinator(service: service);
 
       coordinator.onTrackStarted(_track('a'));
-      await pumpEventQueue();
+      await drainEventQueue(
+        reason: 'without a database there should be no service call',
+      );
 
       expect(service.calls, isEmpty);
     });

--- a/test/services/audio/mix_session_coordinator_test.dart
+++ b/test/services/audio/mix_session_coordinator_test.dart
@@ -27,6 +27,7 @@ import '../../support/fakes/fake_audio_service.dart';
 import '../../support/fakes/fake_source_auth_context.dart';
 import '../../support/isar_test_harness.dart';
 import '../../support/now_playing.dart';
+import '../../support/pump_until.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -178,7 +179,9 @@ void main() {
         expect(coordinator.current, isNull);
         expect(coordinator.pendingLoad, isNull);
         gate.complete();
-        await pumpEventQueue(times: 20);
+        await drainEventQueue(
+          reason: 'let the cancelled load unwind before teardown',
+        );
       },
     );
 
@@ -205,7 +208,9 @@ void main() {
         title: 'Active',
       );
       staleGate.complete();
-      await pumpEventQueue(times: 20);
+      await drainEventQueue(
+        reason: 'the stale session must not append into the newer queue',
+      );
 
       expect(
         coordinatorQueue.tracks.map((t) => t.sourceId),
@@ -249,7 +254,9 @@ void main() {
 
         expect(coordinator.pendingLoad, same(first));
         gate.complete();
-        await pumpEventQueue(times: 20);
+        await drainEventQueue(
+          reason: 'let the single pending load finish before teardown',
+        );
       },
     );
 
@@ -271,12 +278,18 @@ void main() {
         );
 
         coordinator.onTrackStarted(PlayMode.mix);
-        await pumpEventQueue(times: 5);
+        await pumpUntil(
+          () => loadingStates.isNotEmpty,
+          reason: 'starting a mix track should report loading to the caller',
+        );
         expect(loadingStates, [true]);
 
         gate.complete();
         // 佇列寫入是真的 Isar 交易，固定次數的 pump 不是可靠的同步點。
-        await _waitFor(() => loadingStates.length >= 2);
+        await pumpUntil(
+          () => loadingStates.length >= 2,
+          reason: 'the load should report back when it finishes',
+        );
 
         expect(loadingStates, [true, false]);
         expect(queueChangedCount, 1);
@@ -294,7 +307,10 @@ void main() {
       );
 
       coordinator.onTrackStarted(PlayMode.mix);
-      await _waitFor(() => loadingStates.length >= 2);
+      await pumpUntil(
+        () => loadingStates.length >= 2,
+        reason: 'a missing fetcher should report loading and then give up',
+      );
 
       expect(coordinator.canFetch, isFalse);
       expect(loadingStates, [true, false]);
@@ -389,17 +405,27 @@ void main() {
           ],
           startIndex: 1,
         );
-        await pumpEventQueue(times: 5);
+        await pumpUntil(
+          () =>
+              controller.queueState.isMixMode &&
+              controller.queueState.isLoadingMoreMix,
+          reason: 'the mix should enter load-more before the queue is cleared',
+        );
 
         expect(controller.queueState.isMixMode, isTrue);
         expect(controller.queueState.mixTitle, 'First Mix');
         expect(controller.queueState.isLoadingMoreMix, isTrue);
 
         await controller.clearQueue();
-        await pumpEventQueue(times: 5);
+        await pumpUntil(
+          () => !controller.queueState.isMixMode,
+          reason: 'clearing the queue should leave mix mode',
+        );
 
         loadMoreGate.complete();
-        await pumpEventQueue(times: 20);
+        await drainEventQueue(
+          reason: 'the stale load-more must not revive mix mode',
+        );
 
         expect(controller.queueState.isMixMode, isFalse);
         expect(controller.queueState.mixTitle, isNull);
@@ -425,7 +451,12 @@ void main() {
           ],
           startIndex: 1,
         );
-        await pumpEventQueue(times: 5);
+        await pumpUntil(
+          () =>
+              controller.queueState.mixTitle == 'Old Mix' &&
+              controller.queueState.isLoadingMoreMix,
+          reason: 'the old mix should be loading more before it is replaced',
+        );
 
         expect(controller.queueState.isMixMode, isTrue);
         expect(controller.queueState.mixTitle, 'Old Mix');
@@ -442,7 +473,12 @@ void main() {
           ],
           startIndex: 0,
         );
-        await pumpEventQueue(times: 5);
+        await pumpUntil(
+          () =>
+              controller.queueState.mixTitle == 'New Mix' &&
+              controller.state.currentTrack?.sourceId == 'new-a',
+          reason: 'the newer mix should take over the queue',
+        );
 
         expect(controller.queueState.isMixMode, isTrue);
         expect(controller.queueState.mixTitle, 'New Mix');
@@ -451,7 +487,9 @@ void main() {
         expect(controller.queueState.isLoadingMoreMix, isFalse);
 
         staleLoadGate.complete();
-        await pumpEventQueue(times: 20);
+        await drainEventQueue(
+          reason: 'the stale load must not overwrite the newer mix',
+        );
 
         expect(controller.queueState.isMixMode, isTrue);
         expect(controller.queueState.mixTitle, 'New Mix');
@@ -539,15 +577,6 @@ class _FakeSource implements AudioStreamSource {
       codec: 'aac',
       streamType: StreamType.muxed,
     );
-  }
-}
-
-/// 等到 [condition] 成立，或 5 秒逾時。
-Future<void> _waitFor(bool Function() condition) async {
-  final deadline = DateTime.now().add(const Duration(seconds: 5));
-  while (DateTime.now().isBefore(deadline)) {
-    if (condition()) return;
-    await Future<void>.delayed(const Duration(milliseconds: 5));
   }
 }
 

--- a/test/services/audio/play_history_recorder_test.dart
+++ b/test/services/audio/play_history_recorder_test.dart
@@ -9,6 +9,7 @@ import 'package:fmp/services/audio/play_history_recorder.dart';
 import 'package:isar_community/isar.dart';
 
 import '../../support/isar_test_harness.dart';
+import '../../support/pump_until.dart';
 
 /// `PlayHistoryRecorder` 是 Phase 4 步驟 D 抽出來的第一個副作用協作者。
 ///
@@ -72,7 +73,9 @@ void main() {
       final recorder = PlayHistoryRecorder();
 
       recorder.record(_track('a', 'Song A'));
-      await pumpEventQueue();
+      await drainEventQueue(
+        reason: 'without a database nothing should be written',
+      );
 
       expect(await isar.playHistorys.where().count(), 0);
     });
@@ -86,7 +89,9 @@ void main() {
       recorder.record(_track('a', 'Song A'));
 
       // 例外若逃出 microtask，這一輪 pump 會讓測試失敗。
-      await pumpEventQueue();
+      await drainEventQueue(
+        reason: 'a repository failure must not escape the microtask',
+      );
       expect(await isar.playHistorys.where().count(), 0);
     });
   });

--- a/test/services/audio/playback_handoff_gate_test.dart
+++ b/test/services/audio/playback_handoff_gate_test.dart
@@ -126,7 +126,10 @@ void main() {
     });
 
     test('a seek is sent once the stabilization window passes', () async {
-      buildGate(stabilizationDelay: const Duration(milliseconds: 1));
+      // 500ms 不是「夠快」而是「夠慢」：`deferSeek` 只要在視窗還開著的時候被呼叫
+      // 到就行，而它就在下一行。壓到 1ms 反而讓視窗可能先關掉、`deferSeek` 回 null
+      // —— 本輪的壓力跑 20 次抓到 1 次，是同一種競態換了個方向。
+      buildGate(stabilizationDelay: const Duration(milliseconds: 500));
       gate.startStabilizationWindow(7, 'track-a');
       final deferred = gate.deferSeek(const Duration(seconds: 120))!;
 

--- a/test/services/audio/playback_handoff_gate_test.dart
+++ b/test/services/audio/playback_handoff_gate_test.dart
@@ -3,6 +3,8 @@ import 'dart:async';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:fmp/services/audio/playback_handoff_gate.dart';
 
+import '../../support/pump_until.dart';
+
 /// `PlaybackHandoffGate` 是 Phase 4 步驟 C 抽出來的協作者，擁有「控制器正在交接
 /// 一次播放請求」這段期間的狀態：載入閂存、延後中的 seek、切歌後的穩定化視窗。
 ///
@@ -18,23 +20,33 @@ void main() {
 
     const stabilization = Duration(milliseconds: 40);
 
-    setUp(() {
-      seeks = [];
-      trackKey = 'track-a';
-      supersededRequests = {};
+    void buildGate({Duration stabilizationDelay = stabilization}) {
       gate = PlaybackHandoffGate(
         currentTrackKey: () => trackKey,
         performSeek: (position) async => seeks.add(position),
         isRequestSuperseded: supersededRequests.contains,
-        stabilizationDelay: stabilization,
+        stabilizationDelay: stabilizationDelay,
       );
+    }
+
+    setUp(() {
+      seeks = [];
+      trackKey = 'track-a';
+      supersededRequests = {};
+      buildGate();
     });
 
     /// future 完成了沒。作廢路徑漏掉 `complete()` 的話這裡會是 false。
+    ///
+    /// 「還沒完成」等不到，只能推完在途工作再看 —— 所以這裡是刻意的固定圈數。
+    /// 呼叫端有責任確保「完成」不是靠一個真計時器：圈數耗掉的牆鐘時間在滿載的
+    /// 機器上會超過那個計時器，那正是 issue #55。
     Future<bool> settled(Future<void> future) async {
       var done = false;
       unawaited(future.then((_) => done = true));
-      await pumpEventQueue(times: 10);
+      await drainEventQueue(
+        reason: 'let any completion of the deferred seek land',
+      );
       return done;
     }
 
@@ -96,22 +108,38 @@ void main() {
       expect(seeks, isEmpty);
     });
 
-    test(
-      'a seek right after navigation waits out the stabilization window',
-      () async {
-        gate.startStabilizationWindow(7, 'track-a');
-        final deferred = gate.deferSeek(const Duration(seconds: 120))!;
+    // 這裡本來是一條測試，同時守「視窗內延後」與「視窗過後送出」，而它用固定
+    // 圈數的 pump 去斷言前者 —— 圈數耗掉的時間一超過 40ms 視窗，seek 就已經送出
+    // 去了（issue #55）。拆成兩條之後，兩邊各自不再跟時間賽跑。
+    test('a seek inside the stabilization window stays deferred', () async {
+      // 視窗長到任何 pump 預算都追不上，「還沒送出」因此不是時序的巧合。
+      buildGate(stabilizationDelay: const Duration(seconds: 30));
+      gate.startStabilizationWindow(7, 'track-a');
+      final deferred = gate.deferSeek(const Duration(seconds: 120))!;
 
-        expect(await settled(deferred), isFalse);
-        expect(seeks, isEmpty);
+      expect(await settled(deferred), isFalse);
+      expect(seeks, isEmpty);
 
-        await deferred;
+      // 別讓延後中的 seek 掛在那裡跨過測試邊界。
+      gate.cancel(reason: 'test finished');
+      await deferred;
+    });
 
-        expect(seeks, [const Duration(seconds: 120)]);
-        // 視窗過了之後就不再延後。
-        expect(gate.deferSeek(const Duration(seconds: 5)), isNull);
-      },
-    );
+    test('a seek is sent once the stabilization window passes', () async {
+      buildGate(stabilizationDelay: const Duration(milliseconds: 1));
+      gate.startStabilizationWindow(7, 'track-a');
+      final deferred = gate.deferSeek(const Duration(seconds: 120))!;
+
+      await deferred;
+      await pumpUntil(
+        () => seeks.isNotEmpty,
+        reason: 'the deferred seek should be sent after the window',
+      );
+
+      expect(seeks, [const Duration(seconds: 120)]);
+      // 視窗過了之後就不再延後。
+      expect(gate.deferSeek(const Duration(seconds: 5)), isNull);
+    });
 
     test('the stabilize-next flag survives beginRequest but not cancel', () {
       // next()/previous()/playAt() 設下旗標，_executePlayRequest 才取用 ——

--- a/test/services/audio/playback_recovery_coordinator_test.dart
+++ b/test/services/audio/playback_recovery_coordinator_test.dart
@@ -6,6 +6,7 @@ import 'package:fmp/data/models/track.dart';
 import 'package:fmp/services/audio/audio_playback_types.dart';
 import 'package:fmp/services/audio/playback_recovery_coordinator.dart';
 import 'package:fmp/services/audio/playback_request_session.dart';
+
 import '../../support/pump_until.dart';
 
 void main() {

--- a/test/services/audio/playback_recovery_coordinator_test.dart
+++ b/test/services/audio/playback_recovery_coordinator_test.dart
@@ -6,6 +6,7 @@ import 'package:fmp/data/models/track.dart';
 import 'package:fmp/services/audio/audio_playback_types.dart';
 import 'package:fmp/services/audio/playback_recovery_coordinator.dart';
 import 'package:fmp/services/audio/playback_request_session.dart';
+import '../../support/pump_until.dart';
 
 void main() {
   group('PlaybackRecoveryCoordinator', () {
@@ -64,7 +65,10 @@ void main() {
         );
 
         timerFactory.timers.last.fire();
-        await pumpEventQueue();
+        await pumpUntil(
+          () => executor.calls.isNotEmpty,
+          reason: 'the fired retry timer should reach the executor',
+        );
 
         expect(executor.calls.single.mode, PlayMode.mix);
       },
@@ -164,7 +168,10 @@ void main() {
         fallbackPosition: Duration.zero,
         mode: PlayMode.queue,
       );
-      await pumpEventQueue();
+      await pumpUntil(
+        () => events.isNotEmpty,
+        reason: 'a manual retry should emit a retry-started event',
+      );
 
       expect(events, hasLength(1));
       expect(events.single.kind, PlaybackRecoveryEventKind.retryStarted);
@@ -305,8 +312,14 @@ void main() {
 
         for (var i = 0; i < NetworkRetryConfig.maxRetries; i++) {
           timerFactory.timers.last.fire();
-          await pumpEventQueue();
+          await drainEventQueue(reason: 'let each scheduled retry run');
         }
+        await pumpUntil(
+          () =>
+              events.isNotEmpty &&
+              events.last.kind == PlaybackRecoveryEventKind.retryExhausted,
+          reason: 'the retry ladder should reach exhaustion',
+        );
         expect(events.last.kind, PlaybackRecoveryEventKind.retryExhausted);
 
         final event = coordinator.onBackendNetworkError(
@@ -485,7 +498,9 @@ void main() {
       );
       coordinator.reset();
       timerFactory.timers.single.fire();
-      await pumpEventQueue();
+      await drainEventQueue(
+        reason: 'a timer fired after reset must produce nothing',
+      );
 
       expect(events, isEmpty);
       expect(executor.calls, isEmpty);

--- a/test/services/audio/playback_request_session_test.dart
+++ b/test/services/audio/playback_request_session_test.dart
@@ -13,6 +13,7 @@ import 'package:fmp/services/audio/playback_media.dart';
 import 'package:fmp/services/audio/playback_request_session.dart';
 
 import '../../support/fakes/fake_audio_service.dart';
+import '../../support/pump_until.dart';
 
 void main() {
   group('PlaybackSessionResult', () {
@@ -963,7 +964,9 @@ void main() {
           positionAtError: Duration.zero,
         );
         firstPlayGate.complete();
-        await pumpEventQueue(times: 5);
+        await drainEventQueue(
+          reason: 'let the stale first request unwind before the second starts',
+        );
 
         final secondPlayGate = audioService.enqueuePendingPlayUrl();
         final second = session.start(
@@ -1049,7 +1052,9 @@ void main() {
         expect(finishedResults, isEmpty);
 
         playGate.complete();
-        await pumpEventQueue(times: 5);
+        await drainEventQueue(
+          reason: 'let the superseded request finish before teardown',
+        );
       },
     );
 

--- a/test/services/audio/queue_commands_test.dart
+++ b/test/services/audio/queue_commands_test.dart
@@ -15,6 +15,7 @@ import 'package:fmp/services/audio/queue_persistence_manager.dart';
 import 'package:isar_community/isar.dart';
 
 import '../../support/isar_test_harness.dart';
+import '../../support/pump_until.dart';
 
 /// `QueueCommands` 是 Phase 4 步驟 E 從 `AudioController` 抽出來的第一個協作者。
 ///
@@ -80,7 +81,10 @@ void main() {
         addNext.status,
       ], everyElement(QueueMutationStatus.blocked));
       expect(queueManager.tracks, isEmpty);
-      await pumpEventQueue();
+      await pumpUntil(
+        () => toasts.length == 3,
+        reason: 'each blocked mutation should raise its own toast',
+      );
       expect(toasts, hasLength(3));
       expect(toasts.map((t) => t.type), everyElement(ToastType.info));
     });
@@ -89,7 +93,7 @@ void main() {
       final result = await commands.shuffle(isMixMode: true);
 
       expect(result.status, QueueMutationStatus.blocked);
-      await pumpEventQueue();
+      await drainEventQueue(reason: 'a blocked shuffle must stay silent');
       // UI 已經禁用了按鈕，這只是額外保護 —— 再彈一次提示是噪音。
       expect(toasts, isEmpty);
     });

--- a/test/services/audio/temporary_play_handler_test.dart
+++ b/test/services/audio/temporary_play_handler_test.dart
@@ -25,6 +25,7 @@ import '../../support/fakes/fake_audio_service.dart';
 import '../../support/fakes/fake_source_auth_context.dart';
 import '../../support/isar_test_harness.dart';
 import '../../support/now_playing.dart';
+import '../../support/pump_until.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -262,7 +263,10 @@ void main() {
         await controller.playTemporary(tempOne);
 
         queueManager.setCurrentIndex(2);
-        await pumpEventQueue(times: 5);
+        await pumpUntil(
+          () => controller.queueState.currentIndex == 2,
+          reason: 'the queue index move should reach the controller state',
+        );
         audioService.setPositionValue(const Duration(seconds: 7));
         audioService.setPlayingValue(true);
 
@@ -282,7 +286,10 @@ void main() {
         audioService.emitNaturalCompletion();
         await restoreSetUrl;
         await restoreSeek;
-        await pumpEventQueue(times: 20);
+        await pumpUntil(
+          () => controller.state.playingTrack?.sourceId == 'queue-b',
+          reason: 'the temporary track should restore the saved queue entry',
+        );
 
         expect(controller.queueState.currentIndex, 1);
         expect(controller.state.playingTrack?.sourceId, 'queue-b');

--- a/test/services/cache/ranking_cache_service_test.dart
+++ b/test/services/cache/ranking_cache_service_test.dart
@@ -11,6 +11,7 @@ import 'package:fmp/data/sources/source_provider.dart';
 import 'package:fmp/providers/search/popular_provider.dart';
 import 'package:fmp/services/cache/ranking_cache_service.dart';
 import 'package:fmp/services/network/connectivity_service.dart';
+import '../../support/pump_until.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -75,7 +76,10 @@ void main() {
         isTrue,
       );
 
-      await pumpEventQueue(times: 5);
+      await pumpUntil(
+        () => !container.read(rankingCacheServiceProvider).isInitialLoading,
+        reason: 'the initial ranking load should finish',
+      );
       final state = container.read(rankingCacheServiceProvider);
 
       expect(state.isInitialLoading, isFalse);
@@ -142,7 +146,10 @@ void main() {
         );
 
         container.read(rankingCacheServiceProvider);
-        await pumpEventQueue(times: 5);
+        await pumpUntil(
+          () => !container.read(rankingCacheServiceProvider).isInitialLoading,
+          reason: 'the initial ranking load should finish',
+        );
 
         final bilibiliPreview = container.read(
           homeBilibiliMusicRankingProvider,
@@ -475,14 +482,19 @@ void main() {
         final firstService = firstContainer.read(
           rankingCacheServiceProvider.notifier,
         );
-        await pumpEventQueue(times: 5);
+        await pumpUntil(
+          () => firstNeteaseSource.fetchCount == 1,
+          reason: 'the first container should fetch every source once',
+        );
         expect(firstBilibiliSource.fetchCount, 1);
         expect(firstYouTubeSource.fetchCount, 1);
         expect(firstNeteaseSource.fetchCount, 1);
         firstContainer.dispose();
 
         firstNotifier.emitNetworkRecovered();
-        await pumpEventQueue(times: 5);
+        await drainEventQueue(
+          reason: 'a disposed container must not refetch on network recovery',
+        );
         expect(firstBilibiliSource.fetchCount, 1);
         expect(firstYouTubeSource.fetchCount, 1);
         expect(firstNeteaseSource.fetchCount, 1);
@@ -512,13 +524,18 @@ void main() {
 
         expect(identical(firstService, secondService), isFalse);
 
-        await pumpEventQueue(times: 5);
+        await pumpUntil(
+          () => secondNeteaseSource.fetchCount == 1,
+          reason: 'the second container should fetch every source once',
+        );
         expect(secondBilibiliSource.fetchCount, 1);
         expect(secondYouTubeSource.fetchCount, 1);
         expect(secondNeteaseSource.fetchCount, 1);
 
         firstNotifier.emitNetworkRecovered();
-        await pumpEventQueue(times: 5);
+        await drainEventQueue(
+          reason: 'the disposed container must not refetch either container',
+        );
         expect(firstBilibiliSource.fetchCount, 1);
         expect(firstYouTubeSource.fetchCount, 1);
         expect(firstNeteaseSource.fetchCount, 1);
@@ -527,7 +544,10 @@ void main() {
         expect(secondNeteaseSource.fetchCount, 1);
 
         secondNotifier.emitNetworkRecovered();
-        await pumpEventQueue(times: 5);
+        await pumpUntil(
+          () => secondNeteaseSource.fetchCount == 2,
+          reason: 'the live container should refetch on network recovery',
+        );
 
         expect(secondBilibiliSource.fetchCount, 2);
         expect(secondYouTubeSource.fetchCount, 2);

--- a/test/services/cache/ranking_cache_service_test.dart
+++ b/test/services/cache/ranking_cache_service_test.dart
@@ -11,6 +11,7 @@ import 'package:fmp/data/sources/source_provider.dart';
 import 'package:fmp/providers/search/popular_provider.dart';
 import 'package:fmp/services/cache/ranking_cache_service.dart';
 import 'package:fmp/services/network/connectivity_service.dart';
+
 import '../../support/pump_until.dart';
 
 void main() {

--- a/test/services/cache/ranking_cache_service_test.dart
+++ b/test/services/cache/ranking_cache_service_test.dart
@@ -343,7 +343,9 @@ void main() {
       ]);
 
       final oldRefresh = service.refreshSource(SourceIds.netease);
-      await pumpEventQueue();
+      await drainEventQueue(
+        reason: 'let the first refresh reach its gated fetch',
+      );
 
       await service.refreshSource(SourceIds.netease);
       expect(service.state.tracksFor(SourceIds.netease), [newTrack]);
@@ -371,7 +373,9 @@ void main() {
       ]);
 
       final oldRefresh = service.refreshSource(SourceIds.netease);
-      await pumpEventQueue();
+      await drainEventQueue(
+        reason: 'let the first refresh reach its gated fetch',
+      );
 
       await service.refreshSource(SourceIds.netease);
       expect(service.state.tracksFor(SourceIds.netease), isEmpty);
@@ -410,13 +414,18 @@ void main() {
         service.setupNetworkMonitoring(secondNotifier);
 
         firstNotifier.emitNetworkRecovered();
-        await pumpEventQueue();
+        await drainEventQueue(
+          reason: 'a superseded monitor must not trigger a refetch',
+        );
         expect(bilibiliSource.fetchCount, 0);
         expect(youtubeSource.fetchCount, 0);
         expect(neteaseSource.fetchCount, 0);
 
         secondNotifier.emitNetworkRecovered();
-        await pumpEventQueue();
+        await pumpUntil(
+          () => neteaseSource.fetchCount == 1,
+          reason: 'the live monitor should trigger one refetch',
+        );
         expect(bilibiliSource.fetchCount, 1);
         expect(youtubeSource.fetchCount, 1);
         expect(neteaseSource.fetchCount, 1);
@@ -608,7 +617,10 @@ void main() {
         final initializeFuture = service.initialize(
           refreshInterval: const Duration(milliseconds: 20),
         );
-        await pumpEventQueue();
+        await pumpUntil(
+          () => neteaseSource.fetchCount == 1,
+          reason: 'initialize should fetch every source once',
+        );
         expect(bilibiliSource.fetchCount, 1);
         expect(youtubeSource.fetchCount, 1);
         expect(neteaseSource.fetchCount, 1);

--- a/test/services/download/download_service_phase1_test.dart
+++ b/test/services/download/download_service_phase1_test.dart
@@ -27,6 +27,7 @@ import 'package:fmp/services/download/download_service.dart';
 import 'package:isar_community/isar.dart';
 import '../../support/isar_test_harness.dart';
 import 'package:path/path.dart' as p;
+import '../../support/pump_until.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -85,7 +86,9 @@ void main() {
       );
       await service.pauseTask(task.id);
       service.debugFlushPendingProgressUpdatesForTesting();
-      await pumpEventQueue();
+      await drainEventQueue(
+        reason: 'a paused task must flush no progress event',
+      );
 
       expect(service.debugPendingProgressCount, 0);
       expect(events, isEmpty);
@@ -203,7 +206,9 @@ void main() {
       );
       await service.cancelTask(task.id);
       service.debugFlushPendingProgressUpdatesForTesting();
-      await pumpEventQueue();
+      await drainEventQueue(
+        reason: 'a cancelled task must flush no progress event',
+      );
 
       expect(service.debugPendingProgressCount, 0);
       expect(events, isEmpty);

--- a/test/services/radio/radio_controller_phase2_import_test.dart
+++ b/test/services/radio/radio_controller_phase2_import_test.dart
@@ -15,6 +15,7 @@ import 'package:isar_community/isar.dart';
 
 import '../../support/fakes/fake_audio_service.dart';
 import '../../support/isar_test_harness.dart';
+import '../../support/pump_until.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -130,7 +131,7 @@ void main() {
           'https://live.bilibili.com/202',
         ], onProgress: (completed, total) => progress.add('$completed/$total'));
 
-        await harness.pumpUntil(
+        await pumpUntil(
           () => harness.controller.state.stations.length == 2,
           reason: 'watch-driven radio state should reflect the saved import',
         );
@@ -163,19 +164,6 @@ class RadioControllerImportHarness {
   final Isar isar;
   final Directory tempDir;
   final ProviderContainer container;
-
-  Future<void> pumpUntil(
-    bool Function() condition, {
-    required String reason,
-    Duration timeout = const Duration(seconds: 2),
-  }) async {
-    final deadline = DateTime.now().add(timeout);
-    while (DateTime.now().isBefore(deadline)) {
-      if (condition()) return;
-      await Future<void>.delayed(const Duration(milliseconds: 10));
-    }
-    if (!condition()) fail(reason);
-  }
 
   Future<void> dispose() async {
     container.dispose();
@@ -230,7 +218,7 @@ Future<RadioControllerImportHarness> createHarness({
   );
   await Future<void>.delayed(const Duration(milliseconds: 50));
   if (waitForInitialLoad) {
-    await harness.pumpUntil(
+    await pumpUntil(
       () => controller.state.stations.length == initialStations.length,
       reason: 'controller should load initial radio state',
     );

--- a/test/services/radio/radio_controller_refresh_stale_test.dart
+++ b/test/services/radio/radio_controller_refresh_stale_test.dart
@@ -71,7 +71,7 @@ void main() {
     addTearDown(service.dispose);
 
     service.setRepository(repository);
-    await _pumpUntil(
+    await pumpUntil(
       () => repository.getAllCalls == 1,
       reason: 'initial setRepository refresh should run with no stations',
     );
@@ -81,7 +81,7 @@ void main() {
     ];
 
     final oldRefresh = service.refreshAll();
-    await _pumpUntil(
+    await pumpUntil(
       () => source.liveInfoCalls.length == 1,
       reason: 'old refresh should request live info',
     );
@@ -114,7 +114,7 @@ void main() {
         radioSource: _CompletingRadioSource(),
       );
 
-      await _pumpUntil(
+      await pumpUntil(
         () => controller.state.stations.length == 1,
         reason: 'controller should load stations before manual refresh',
       );
@@ -143,19 +143,6 @@ RadioStation _station({
     ..sourceType = SourceIds.bilibili
     ..sourceId = sourceId
     ..title = title;
-}
-
-Future<void> _pumpUntil(
-  bool Function() condition, {
-  required String reason,
-  Duration timeout = const Duration(seconds: 2),
-}) async {
-  final deadline = DateTime.now().add(timeout);
-  while (DateTime.now().isBefore(deadline)) {
-    if (condition()) return;
-    await Future<void>.delayed(const Duration(milliseconds: 10));
-  }
-  if (!condition()) fail(reason);
 }
 
 extension on RadioController {

--- a/test/services/radio/radio_controller_refresh_stale_test.dart
+++ b/test/services/radio/radio_controller_refresh_stale_test.dart
@@ -14,6 +14,7 @@ import 'package:isar_community/isar.dart';
 
 import '../../support/fakes/fake_audio_service.dart';
 import '../../support/fakes/fake_isar.dart';
+import '../../support/pump_until.dart';
 
 void main() {
   setUpAll(() {
@@ -43,7 +44,10 @@ void main() {
       );
 
       final refreshFuture = controller.refreshStationInfo();
-      await pumpEventQueue(times: 2);
+      await pumpUntil(
+        () => source.calls.isNotEmpty,
+        reason: 'the refresh should reach the source',
+      );
       expect(source.calls, ['101']);
 
       controller.setSeedState(

--- a/test/services/radio/radio_controller_refresh_stale_test.dart
+++ b/test/services/radio/radio_controller_refresh_stale_test.dart
@@ -121,7 +121,14 @@ void main() {
 
       AppLogger.clearLogs();
       await controller.refreshAllLiveStatus();
-      await pumpEventQueue();
+      await pumpUntil(
+        () => AppLogger.logs.any(
+          (entry) =>
+              entry.tag == 'RadioController' &&
+              entry.message.startsWith('同步直播狀態'),
+        ),
+        reason: 'the manual refresh should log one sync line',
+      );
 
       final syncLogs = AppLogger.logs.where(
         (entry) =>

--- a/test/support/fakes/count_waiters.dart
+++ b/test/support/fakes/count_waiters.dart
@@ -1,0 +1,40 @@
+import 'dart:async';
+
+/// 「呼叫次數達到 N」的等待清單。
+///
+/// 假物件用它讓測試等到「呼叫真的發生了」，而不是猜幾圈事件迴圈夠不夠
+/// （見 `test/support/pump_until.dart` 與 issue #43）。次數只增不減，所以等待
+/// 不會錯過某個瞬間 —— 這是它比條件式輪詢更適合「呼叫次數」的地方。
+class CountWaiters {
+  CountWaiters(this._count);
+
+  /// 目前的呼叫次數。
+  final int Function() _count;
+
+  final List<_Waiter> _waiters = [];
+
+  /// 等到呼叫次數達到 [target]。已經達到就立刻返回。
+  Future<void> waitFor(int target) {
+    if (_count() >= target) return Future.value();
+    final completer = Completer<void>();
+    _waiters.add(_Waiter(target, completer));
+    return completer.future;
+  }
+
+  /// 記錄完一次呼叫之後叫它。
+  void notify() {
+    for (final waiter in List<_Waiter>.from(_waiters)) {
+      if (_count() >= waiter.target && !waiter.completer.isCompleted) {
+        waiter.completer.complete();
+        _waiters.remove(waiter);
+      }
+    }
+  }
+}
+
+class _Waiter {
+  _Waiter(this.target, this.completer);
+
+  final int target;
+  final Completer<void> completer;
+}

--- a/test/support/fakes/fake_audio_service.dart
+++ b/test/support/fakes/fake_audio_service.dart
@@ -6,6 +6,8 @@ import 'package:fmp/services/audio/audio_service.dart';
 import 'package:fmp/services/audio/audio_types.dart';
 import 'package:fmp/services/audio/playback_media.dart';
 
+import 'count_waiters.dart';
+
 class AudioUrlCall {
   AudioUrlCall({required this.url, this.headers, this.track});
 
@@ -65,9 +67,9 @@ class FakeAudioService implements FmpAudioService {
   final List<Completer<void>> _pendingPlay = [];
   final List<Object> _stopErrors = [];
   final List<Object> _playUrlErrors = [];
-  final List<_CountWaiter> _playUrlWaiters = [];
-  final List<_CountWaiter> _setUrlWaiters = [];
-  final List<_CountWaiter> _seekWaiters = [];
+  late final _playUrlWaiters = CountWaiters(() => playUrlCalls.length);
+  late final _setUrlWaiters = CountWaiters(() => setUrlCalls.length);
+  late final _seekWaiters = CountWaiters(() => seekCalls.length);
 
   bool _isPlaying = false;
   Duration _position = Duration.zero;
@@ -117,26 +119,13 @@ class FakeAudioService implements FmpAudioService {
     _playUrlErrors.add(error);
   }
 
-  Future<void> waitForPlayUrlCallCount(int count) {
-    if (playUrlCalls.length >= count) return Future.value();
-    final completer = Completer<void>();
-    _playUrlWaiters.add(_CountWaiter(count, completer));
-    return completer.future;
-  }
+  Future<void> waitForPlayUrlCallCount(int count) =>
+      _playUrlWaiters.waitFor(count);
 
-  Future<void> waitForSetUrlCallCount(int count) {
-    if (setUrlCalls.length >= count) return Future.value();
-    final completer = Completer<void>();
-    _setUrlWaiters.add(_CountWaiter(count, completer));
-    return completer.future;
-  }
+  Future<void> waitForSetUrlCallCount(int count) =>
+      _setUrlWaiters.waitFor(count);
 
-  Future<void> waitForSeekCallCount(int count) {
-    if (seekCalls.length >= count) return Future.value();
-    final completer = Completer<void>();
-    _seekWaiters.add(_CountWaiter(count, completer));
-    return completer.future;
-  }
+  Future<void> waitForSeekCallCount(int count) => _seekWaiters.waitFor(count);
 
   void setPositionValue(Duration position) {
     _position = position;
@@ -208,35 +197,6 @@ class FakeAudioService implements FmpAudioService {
   void emitAudioDevices(List<FmpAudioDevice> devices) {
     _audioDevices = devices;
     _audioDevicesController.add(devices);
-  }
-
-  void _notifyPlayUrlWaiters() {
-    for (final waiter in List<_CountWaiter>.from(_playUrlWaiters)) {
-      if (playUrlCalls.length >= waiter.target &&
-          !waiter.completer.isCompleted) {
-        waiter.completer.complete();
-        _playUrlWaiters.remove(waiter);
-      }
-    }
-  }
-
-  void _notifySetUrlWaiters() {
-    for (final waiter in List<_CountWaiter>.from(_setUrlWaiters)) {
-      if (setUrlCalls.length >= waiter.target &&
-          !waiter.completer.isCompleted) {
-        waiter.completer.complete();
-        _setUrlWaiters.remove(waiter);
-      }
-    }
-  }
-
-  void _notifySeekWaiters() {
-    for (final waiter in List<_CountWaiter>.from(_seekWaiters)) {
-      if (seekCalls.length >= waiter.target && !waiter.completer.isCompleted) {
-        waiter.completer.complete();
-        _seekWaiters.remove(waiter);
-      }
-    }
   }
 
   Future<void> _awaitPending(List<Completer<void>> pending) async {
@@ -357,7 +317,7 @@ class FakeAudioService implements FmpAudioService {
   @override
   Future<void> seekTo(Duration position) async {
     seekCalls.add(position);
-    _notifySeekWaiters();
+    _seekWaiters.notify();
     await _awaitPending(_pendingSeek);
     _position = position;
     _emitState();
@@ -431,7 +391,7 @@ class FakeAudioService implements FmpAudioService {
     Track? track,
   }) async {
     playUrlCalls.add(AudioUrlCall(url: url, headers: headers, track: track));
-    _notifyPlayUrlWaiters();
+    _playUrlWaiters.notify();
     await _awaitPending(_pendingPlayUrl);
     if (_playUrlErrors.isNotEmpty) {
       throw _playUrlErrors.removeAt(0);
@@ -449,7 +409,7 @@ class FakeAudioService implements FmpAudioService {
     Track? track,
   }) async {
     setUrlCalls.add(AudioUrlCall(url: url, headers: headers, track: track));
-    _notifySetUrlWaiters();
+    _setUrlWaiters.notify();
     await _awaitPending(_pendingSetUrl);
     _processingState = FmpAudioProcessingState.ready;
     _emitState();
@@ -472,11 +432,4 @@ class FakeAudioService implements FmpAudioService {
     _emitState();
     return _duration;
   }
-}
-
-class _CountWaiter {
-  _CountWaiter(this.target, this.completer);
-
-  final int target;
-  final Completer<void> completer;
 }

--- a/test/support/pump_until.dart
+++ b/test/support/pump_until.dart
@@ -1,0 +1,67 @@
+import 'package:flutter_test/flutter_test.dart';
+
+/// 開頭「只推事件迴圈、不睡」的輪數上限。
+///
+/// 沿用被它取代的那些區域 helper 的 `maxPumps = 50`；一輪是
+/// `pumpEventQueue()` 的 20 圈，所以是 1000 圈事件迴圈。
+const _busyRounds = 50;
+
+/// 等到 [condition] 成立為止，最多等 [timeout]。
+///
+/// 取代 `await pumpEventQueue(times: N)` 之後緊接斷言的寫法。`times` 數的是事件
+/// 迴圈的圈數 —— `pumpEventQueue` 每一圈只是排一個零延遲的 `Timer`，而圈數換不到
+/// 「進度」：背景 I/O、Isar 交易與真計時器什麼時候完成跟圈數無關。機器滿載時
+/// 同樣的圈數換到的進度更少，正向斷言就落在還沒收斂的狀態上（issue #43）；反過來
+/// 同樣的圈數耗掉的牆鐘時間更多，「還沒發生」的斷言就會提早成立（issue #55）。
+/// 兩個方向壞在相反的地方，所以把圈數調大不是修，只是把競態換一邊 —— 這裡改用
+/// 牆鐘期限。
+///
+/// **[condition] 必須是「進入時還不成立」的東西。** 一進來就成立的條件會讓這個
+/// 函式立刻返回、一圈都沒推，比它取代掉的固定圈數**更少**推進；那不是等待。
+///
+/// 等的方式分兩段，兩段都是量出來的，不是選出來的：
+///
+/// - 前 [_busyRounds] 輪用 `pumpEventQueue()`，**不耗牆鐘時間**。睡覺會讓真計時器
+///   提早到期，本身就會改變被測程式的行為，而且會整段錯過只存在幾圈的瞬間狀態。
+/// - 一輪是完整的 `pumpEventQueue()`（20 圈），不是一圈。改成一圈一檢查會讓等待
+///   在更早的時點返回，而呼叫端的下一步就落在不同的交錯上 ——
+///   `audio_controller_phase1_test` 的「superseded source error」那條會因此卡死。
+///   20 圈是套件裡既有區域 helper 一直在用的粒度。
+/// - 之後改成睡 10ms。走到這裡通常是在等一個真計時器，熱迴圈只會讓滿載的機器
+///   更慢，而這正是本來要修的病。
+///
+/// [reason] 是必填的：逾時訊息是這個 helper 唯一的產出，寫「在等什麼」而不是
+/// 「等待失敗了」。
+///
+/// 條件一成立就返回，所以放寬 [timeout] 不會讓任何原本會過的測試變慢。預設的
+/// 5 秒遠低於 `test` 的 30 秒預設逾時，逾時訊息因此留得下來。
+Future<void> pumpUntil(
+  bool Function() condition, {
+  required String reason,
+  Duration timeout = const Duration(seconds: 5),
+}) async {
+  final deadline = DateTime.now().add(timeout);
+  var round = 0;
+  while (DateTime.now().isBefore(deadline)) {
+    if (condition()) return;
+    if (round++ < _busyRounds) {
+      await pumpEventQueue();
+    } else {
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+    }
+  }
+  if (!condition()) fail('timed out after $timeout waiting: $reason');
+}
+
+/// 推進事件佇列固定圈數，給「某件事**不該**發生」的斷言用。
+///
+/// 條件式等待對這種斷言沒有意義 —— 條件在第 0 圈就成立，[pumpUntil] 會立刻返回，
+/// 什麼都沒等到。首選是先用 [pumpUntil] 等一個**排在它之後**的里程碑，再斷言那件事
+/// 沒發生；真的找不到里程碑時才用這個，並在 [reason] 寫下它替代的是什麼。
+///
+/// [reason] 只有人會讀。它的作用是讓 `rg drainEventQueue` 一次列出全部「我們知道
+/// 自己在斷言缺席」的地方 —— 註解做不到這件事。
+Future<void> drainEventQueue({required String reason, int times = 20}) {
+  assert(reason.isNotEmpty, 'drainEventQueue needs a reason');
+  return pumpEventQueue(times: times);
+}

--- a/test/support/pump_until_test.dart
+++ b/test/support/pump_until_test.dart
@@ -1,0 +1,68 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'pump_until.dart';
+
+void main() {
+  group('pumpUntil', () {
+    test('a fixed pump count is not a synchronisation point', () async {
+      var late = false;
+      final timer = Timer(const Duration(seconds: 3), () => late = true);
+      addTearDown(timer.cancel);
+
+      // 10 圈事件迴圈就是 10 個零延遲的 Timer，跑完是微秒等級的事 —— 不可能等到
+      // 一個 3 秒後才到期的計時器。這條斷言的方向是確定的（事件迴圈不會自己耗掉
+      // 3 秒），而它守的正是 issue #43 / #55 那個形狀。
+      await pumpEventQueue(times: 10);
+
+      expect(late, isFalse);
+    });
+
+    test('waits for a real timer', () async {
+      var fired = false;
+      Timer(const Duration(milliseconds: 50), () => fired = true);
+
+      await pumpUntil(() => fired, reason: 'the 50ms timer should fire');
+
+      expect(fired, isTrue);
+    });
+
+    test('returns without waiting when the condition already holds', () async {
+      // timeout 是 0，所以迴圈一圈都跑不到；能過就代表它沒有先等再檢查。
+      await pumpUntil(
+        () => true,
+        reason: 'an already-true condition',
+        timeout: Duration.zero,
+      );
+    });
+
+    test('fails with the reason when the condition never holds', () async {
+      await expectLater(
+        pumpUntil(
+          () => false,
+          reason: 'a condition that never holds',
+          timeout: const Duration(milliseconds: 50),
+        ),
+        throwsA(
+          isA<TestFailure>().having(
+            (failure) => failure.message,
+            'message',
+            contains('a condition that never holds'),
+          ),
+        ),
+      );
+    });
+  });
+
+  group('drainEventQueue', () {
+    test('lets already-queued work run', () async {
+      var ran = false;
+      unawaited(Future<void>.microtask(() => ran = true));
+
+      await drainEventQueue(reason: 'queued microtasks should have run');
+
+      expect(ran, isTrue);
+    });
+  });
+}

--- a/test/support/wait_convention_static_rule_test.dart
+++ b/test/support/wait_convention_static_rule_test.dart
@@ -1,0 +1,89 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// 唯一允許直接呼叫 `pumpEventQueue` 的地方。
+///
+/// `pump_until.dart` 是包裝它的那一層；它自己的測試要拿原始的固定圈數來當對照，
+/// 證明「圈數不是同步點」；本檔的合成違規樣本存在字串常量裡，會被自己掃到。
+const _allowedFiles = <String>[
+  'test/support/pump_until.dart',
+  'test/support/pump_until_test.dart',
+  'test/support/wait_convention_static_rule_test.dart',
+];
+
+/// 找出直接呼叫 `pumpEventQueue` 的行。
+///
+/// 註解不算 —— 有幾份說明本來就在講這個 API 為什麼不可靠。
+List<String> fixedPumpOffenders(String path, String source) {
+  final offenders = <String>[];
+  final lines = source.split('\n');
+  for (var i = 0; i < lines.length; i++) {
+    final code = lines[i].trim();
+    if (code.startsWith('//')) continue;
+    if (!code.contains('pumpEventQueue(')) continue;
+    offenders.add('$path:${i + 1}: ${code.trim()}');
+  }
+  return offenders;
+}
+
+void main() {
+  group('fixed pump counts', () {
+    test('only pump_until.dart calls pumpEventQueue directly', () {
+      final offenders = <String>[];
+      var scanned = 0;
+
+      for (final entity in Directory('test').listSync(recursive: true)) {
+        if (entity is! File || !entity.path.endsWith('.dart')) continue;
+        final path = entity.path.replaceAll(r'\', '/');
+        if (_allowedFiles.contains(path)) continue;
+
+        scanned++;
+        offenders.addAll(fixedPumpOffenders(path, entity.readAsStringSync()));
+      }
+
+      // 掃描本身要有作用 —— 路徑寫錯時 offenders 也會是空的。
+      expect(scanned, greaterThan(200));
+      expect(
+        offenders,
+        isEmpty,
+        reason:
+            'A fixed pump count is not a synchronisation point (issue #43/#55). '
+            'Use pumpUntil for a condition, or drainEventQueue when asserting '
+            'that something did not happen. See test/support/pump_until.dart.',
+      );
+    });
+
+    test('every allowlist entry still exists', () {
+      for (final path in _allowedFiles) {
+        expect(
+          File(path).existsSync(),
+          isTrue,
+          reason: '$path is allowlisted but no longer exists',
+        );
+      }
+    });
+
+    test('guard detects a fixed pump before an assertion', () {
+      const source = '''
+test('something', () async {
+  controller.playTrack(track);
+  await pumpEventQueue(times: 10);
+  expect(toasts, isNotEmpty);
+});
+''';
+
+      expect(fixedPumpOffenders('test/fake_test.dart', source), hasLength(1));
+    });
+
+    test('guard ignores comments that mention the api', () {
+      const source = '''
+/// 單次 `pumpEventQueue()` 只等得到第一筆寫入。
+// await pumpEventQueue(times: 5);
+await pumpUntil(() => done, reason: 'the write to land');
+''';
+
+      expect(fixedPumpOffenders('test/fake_test.dart', source), isEmpty);
+    });
+  });
+}


### PR DESCRIPTION
關掉 #43 與 #55。

2026-09-07 一天內 CI 紅了 7 次，**其中 4 次是同一種毛病**，包含 `main` 上的一次
（run `34120654888`，12:12–12:42 main 是紅的）。另外兩次是 dependabot PR ——
那兩次的紅跟升級毫無關係，也是同一條抖動。

## 根因是一個形狀，不是一條測試

```dart
await pumpEventQueue(times: 10);   // 等 10 圈事件迴圈
expect(toasts, isNotEmpty);        // 立刻斷言
```

`pumpEventQueue` 只是遞迴排零延遲的 `Timer`（`test_api/lib/src/scaffolding/utils.dart:16`）。
**圈數換不到「進度」**：背景 I/O、Isar 交易與真計時器什麼時候完成跟圈數無關。
滿載時同樣的圈數換到的進度更少（正向斷言掛掉，#43）；反過來同樣的圈數耗掉的牆鐘
時間更多，「還沒發生」提早變成「已經發生」（#55）。**兩個方向壞在相反的地方 ——
把圈數調大不是修，只是把競態換一邊。**

## 做了什麼

| 項目 | 數字 |
|---|---|
| `pumpEventQueue` 呼叫點移除 | **194**（167 個 `times: N` + 27 個不帶參數） |
| 換成 `pumpUntil`（條件式等待，牆鐘期限） | 182 處 |
| 換成 `drainEventQueue`（斷言「沒發生」） | 58 處 |
| 收斂掉的區域 wait helper / `_CountWaiter` | 10 份 / 3 份 |

- **`test/support/pump_until.dart`** —— 共用的條件式等待。前 50 輪用完整的
  `pumpEventQueue()`（不耗牆鐘時間），之後才睡 10ms；兩段都是量出來的，理由寫在
  文檔註釋裡。
- **`drainEventQueue`** —— 「某件事不該發生」的斷言等不到任何條件。首選是先用
  `pumpUntil` 等一個排在它之後的里程碑再斷言缺席；找不到里程碑時才用它，而
  `reason` 讓 `rg drainEventQueue` 一次列出全部這種地方。
- **`test/support/wait_convention_static_rule_test.dart`** —— **完全禁止**在
  `test/` 呼叫 `pumpEventQueue`（三個檔案豁免），規則同步寫進根 `AGENTS.md`。

## 為什麼範圍比 issue 寫的大

issue #43 建議的範圍是「同檔案、pump 之後緊接斷言」。本輪先建了對照組
（4 核 affinity、獨立 worktree、各跑 20 次），**改動前 20 次 2 紅**，抓到的是
之前沒記錄過的第三條失敗：`prepareCurrentTrack prefetch` 那條的斷言隔了幾行才出現，
按「緊接斷言」的規則會被判定為安全而留下來。不帶參數的 `pumpEventQueue()` 也是
`times: 20`，同一個病。守門規則因此定成完全禁止。

## 兩個踩到的陷阱（都寫進文檔註釋）

1. **輪詢方式是承重的。** 照抄既有的「睡 10ms」形狀之後，`superseded source error`
   那條**永遠**等不到它要的狀態；改成一圈一檢查又太細，同一條測試直接卡死。
2. **條件在進入時就成立 = 一圈都沒推**，比它取代掉的固定圈數推進得更少。有兩條測試
   因此變紅。

## 驗收

| 項目 | 結果 |
|---|---|
| 完整套件 | **1505 passed**（基準 1495） |
| `flutter analyze` | 乾淨 |
| `dart format lib test` | 577 檔 0 diff |
| 壓力跑（改動前 / 後） | **20 次 2 紅** / **25 次 0 紅** |

壓力跑方法：`ProcessorAffinity` 限成 4 核（GitHub public repo runner 規格），
子行程繼承，在 `git worktree` 的獨立副本上跑
`audio_controller_phase1_test.dart` + `playback_handoff_gate_test.dart`。

**改動後的第一輪 20 次有 1 紅，而且是本輪自己種下的**：#55 拆出來的第二條測試
一開始用 1ms 視窗，那是同一種競態換了個方向 —— `deferSeek` 可能在視窗關掉之後才
被呼叫而回 `null`。改成 500ms（需要的只是「視窗在下一行還開著」）之後補跑，
19 + 6 = 25 次 0 紅。另有 1 次在 1 秒內失敗、完全沒有測試輸出（行程沒起來，
當時主工作樹正在跑完整套件），那不是測試失敗，沒有計入。

**這證明不了「已經沒有抖動」** —— 既有基準是 24 次 1 紅，要證到 0 需要 70 次以上。
證的是：已知的機制被移除了，改動前重現得出的失敗在改動後不再出現，守門測試擋住它
回來。

**不需要實機驗證** —— 純測試改動，沒有任何 user-visible 行為變更。

詳細記錄：`docs/review/05-roadmap.md` §6.15。
