### PR TITLE
test(sources): stop the invalid bvid test from hitting the network

### DIFF
--- a/test/bilibili_source_test.dart
+++ b/test/bilibili_source_test.dart
@@ -865,11 +865,27 @@ void main() {
       }, tags: 'live');
 
       test('should throw BilibiliApiException for invalid bvid', () async {
-        const invalidBvid = 'BV1234567890'; // 无效的BV号
+        // 「無效 bvid 回 BilibiliApiException」不需要真的 B 站，所以走同檔既有
+        // 的 loopback server 寫法。原本它用外層 setUp 那個真連網的 source 又
+        // 沒標 live，CI 的 --exclude-tags live 攔不住，上游一變動就會把不相干
+        // 的 PR 弄紅。
+        final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+        addTearDown(() async => server.close(force: true));
 
-        expect(
-          () => source.getAudioUrl(
-            const AudioStreamRequest(sourceId: invalidBvid),
+        server.listen((request) async {
+          request.response.headers.contentType = ContentType.json;
+          request.response.write(jsonEncode({'code': -400, 'message': '请求错误'}));
+          await request.response.close();
+        });
+        final source = BilibiliSource(
+          apiBase: 'http://localhost:${server.port}',
+        );
+
+        // await expectLater，不是 expect：非同步的 rejection 若沒有 await，會在
+        // 這條測試結束之後才浮出來，失敗被算到下一條頭上。
+        await expectLater(
+          source.getAudioUrl(
+            const AudioStreamRequest(sourceId: 'BV1234567890'),
           ),
           throwsA(isA<BilibiliApiException>()),
         );
@@ -1024,22 +1040,6 @@ void main() {
 
         expect(track.hasValidAudioUrl, isFalse);
       });
-    });
-  });
-
-  group('Race Condition Prevention', () {
-    test('Multiple rapid play requests should not cause errors', () async {
-      // 这个测试模拟快速切歌的场景
-      // 实际测试需要模拟 AudioController，这里只是占位符
-      // 真实测试需要使用 mocktail 或 mockito 来模拟依赖
-
-      // 模拟场景：
-      // 1. 请求播放歌曲A
-      // 2. 在A还没加载完时，请求播放歌曲B
-      // 3. 歌曲A的加载应该被取消，歌曲B应该正常播放
-
-      // 这里只验证逻辑概念
-      expect(true, isTrue);
     });
   });
 }


### PR DESCRIPTION
關掉 #56。

`test/bilibili_source_test.dart` 的 `should throw BilibiliApiException for invalid bvid`
用的是該 group `setUp` 建的 `BilibiliSource()` —— **真的 Dio、真的網路** —— 而且沒標
`tags: 'live'`，所以 CI 的 `--exclude-tags live` 攔不住它。同檔另外兩條同性質的測試在
`598fce27` 就標上了，這一條被漏掉。

這正是上一輪整輪在處理的失效模式：**上游 API 一變動，不相干的 PR 就會紅**，CI 結果因此
不可讀。

## 改成不需要網路，而不是標 live

標 live 會讓覆蓋直接消失。改用同檔既有的 loopback `HttpServer` 寫法（`:492`、`:547`
是範例）——「無效 bvid 回 `BilibiliApiException`」本來就不需要真的 B 站。

反向驗證過它不是恆真：把假伺服器的 `code` 從 `-400` 改成 `0`，測試會紅
（`Expected: throws <Instance of 'BilibiliApiException'>`）。

## 非同步斷言補上 await

```dart
- expect(() => source.getAudioUrl(...), throwsA(isA<BilibiliApiException>()));
+ await expectLater(source.getAudioUrl(...), throwsA(isA<BilibiliApiException>()));
```

沒有 `await` 的話，rejection 可能在這條測試結束之後才浮出來，失敗被算到**下一條**
測試頭上，或變成看不出來源的 unhandled async error。同檔其他地方本來就用
`await expectLater`，這條是例外。

## 刪掉一條不驗任何東西的測試

`Race Condition Prevention / Multiple rapid play requests should not cause errors`
的測試體是 `expect(true, isTrue);`，註釋自承「这里只是占位符」。它會計進通過數但不驗
任何行為。Phase 0 刪 `test/widget_test.dart` 是同一個理由。

## 順手掃過同類

- `test/live/sources_live_test.dart` 有 library 層的 `@Tags(['live'])`，`dart_test.yaml`
  也宣告了該 tag —— 正確排除中。
- `test/data/sources/netease_source_test.dart` 的 `NeteaseSource()` 只呼叫
  `parseId` / `isPlaylistUrl` / `canHandle`，純 URL 解析，不連網。
- 把 `bilibili_source_test` 那個共用 `source` 的 `apiBase` 指到一個拒絕連線的 port
  之後，**21 條非 live 測試全過** —— 確認沒有其他非 live 測試依賴它連得上網。

## 驗收

| 項目 | 結果 |
|---|---|
| 完整套件 | **1509 passed**（原 1510，−1 是刪掉的佔位測試） |
| `flutter analyze` | 乾淨 |
| `dart format lib test` | 578 檔 0 diff |
| 反向驗證 | 假伺服器回 `code: 0` 時該測試變紅 |

**不需要實機驗證** —— 純測試改動，無 user-visible 行為變更。
