### PR TITLE
chore(deps): keep breaking 0.x bumps out of the grouped update

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,7 +16,30 @@ updates:
       interval: 'weekly'
     # Major bumps stay ungrouped: they need their own PR because each one can
     # carry breaking changes that have to be reviewed and verified separately.
+    #
+    # Dependabot classifies by version position, so for a 0.x package it calls
+    # 0.9 -> 0.10 a *minor* update. Pub does not: `^0.9.40` refuses 0.10, and
+    # such a bump is breaking. PR #59 grouped five of them under
+    # "minor-and-patch" -- just_audio, audio_session, tray_manager,
+    # window_manager and inno_bundle, i.e. the audio backend, the tray, window
+    # management and the installer. Every direct dependency still on 0.x is
+    # therefore excluded so it arrives as its own reviewable PR.
+    # test/workflows/dependabot_group_static_rule_test.dart fails when a 0.x
+    # direct dependency is missing from this list.
     groups:
       pub-minor-and-patch:
         patterns: ['*']
+        exclude-patterns:
+          - 'audio_service'
+          - 'audio_session'
+          - 'desktop_multi_window'
+          - 'flutter_launcher_icons'
+          - 'hotkey_manager'
+          - 'inno_bundle'
+          - 'just_audio'
+          - 'launch_at_startup'
+          - 'rxdart'
+          - 'scrollable_positioned_list'
+          - 'tray_manager'
+          - 'window_manager'
         update-types: ['minor', 'patch']

--- a/test/workflows/dependabot_group_static_rule_test.dart
+++ b/test/workflows/dependabot_group_static_rule_test.dart
@@ -1,0 +1,129 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// Dependabot 依版號位置分類，所以對 0.x 套件它把 `0.9 -> 0.10` 叫作 *minor*。
+/// pub 不是這樣算的：`^0.9.40` 不接受 0.10，那是破壞性變更。
+///
+/// PR #59 就是這樣把五個破壞性升級包進一個叫「minor-and-patch」的 PR：
+/// just_audio、audio_session、tray_manager、window_manager、inno_bundle ——
+/// 音訊後端、系統匣、視窗管理與安裝檔打包。
+///
+/// `.github/dependabot.yml` 因此逐一排除仍在 0.x 的直接依賴。清單會隨著套件
+/// 各自走到 1.0 而漂移，所以由這條規則守著：**新增一個 0.x 依賴卻忘了排除**
+/// 會紅，而**排除了一個已經離開 0.x 的套件**也會紅。
+void main() {
+  group('dependabot grouping', () {
+    late Set<String> zeroVersion;
+    late Set<String> excluded;
+
+    setUp(() {
+      zeroVersion = zeroVersionDirectDependencies(
+        File('pubspec.yaml').readAsStringSync(),
+      );
+      excluded = groupExcludePatterns(
+        File('.github/dependabot.yml').readAsStringSync(),
+      );
+    });
+
+    test('every 0.x direct dependency is excluded from the group', () {
+      // 解析本身要有作用 —— 格式一變，兩個集合都會是空的。
+      expect(zeroVersion, isNotEmpty);
+      expect(
+        zeroVersion.difference(excluded),
+        isEmpty,
+        reason:
+            'a 0.x dependency would be grouped as minor; add it to '
+            'exclude-patterns so its bump arrives as its own PR',
+      );
+    });
+
+    test('no exclusion names a dependency that left 0.x', () {
+      expect(
+        excluded.difference(zeroVersion),
+        isEmpty,
+        reason:
+            'this dependency is no longer 0.x (or no longer a dependency); '
+            'drop it from exclude-patterns',
+      );
+    });
+
+    test('the pubspec parser reads versions, not sdk or hosted entries', () {
+      const pubspec = '''
+environment:
+  sdk: ^3.9.0
+
+dependencies:
+  flutter:
+    sdk: flutter
+  dio: ^5.9.2
+  just_audio: ^0.9.40             # Android 音频后端
+  isar_community:
+    hosted: https://example.test
+
+dev_dependencies:
+  inno_bundle: ^0.11.2
+
+flutter:
+  uses-material-design: true
+''';
+      expect(zeroVersionDirectDependencies(pubspec), {
+        'just_audio',
+        'inno_bundle',
+      });
+    });
+
+    test('the dependabot parser stops at the end of the list', () {
+      const config = '''
+    groups:
+      pub-minor-and-patch:
+        patterns: ['*']
+        exclude-patterns:
+          - 'just_audio'
+          - 'tray_manager'
+        update-types: ['minor', 'patch']
+''';
+      expect(groupExcludePatterns(config), {'just_audio', 'tray_manager'});
+    });
+  });
+}
+
+/// `pubspec.yaml` 的 `dependencies:` / `dev_dependencies:` 裡版本仍在 0.x 的項目。
+Set<String> zeroVersionDirectDependencies(String pubspec) {
+  final names = <String>{};
+  var inDependencies = false;
+
+  for (final line in const LineSplitter().convert(pubspec)) {
+    if (!line.startsWith(' ') && line.trim().isNotEmpty) {
+      inDependencies =
+          line.startsWith('dependencies:') ||
+          line.startsWith('dev_dependencies:');
+      continue;
+    }
+    if (!inDependencies) continue;
+
+    final match = RegExp(r"^  ([a-z0-9_]+):\s*\^?(0\.\S*)").firstMatch(line);
+    if (match != null) names.add(match.group(1)!);
+  }
+  return names;
+}
+
+/// `.github/dependabot.yml` 的 `exclude-patterns:` 清單。
+Set<String> groupExcludePatterns(String config) {
+  final names = <String>{};
+  var inList = false;
+
+  for (final line in const LineSplitter().convert(config)) {
+    if (line.trimRight().endsWith('exclude-patterns:')) {
+      inList = true;
+      continue;
+    }
+    if (!inList) continue;
+
+    final match = RegExp(r"^\s+- '([^']+)'\s*$").firstMatch(line);
+    if (match == null) break;
+    names.add(match.group(1)!);
+  }
+  return names;
+}


### PR DESCRIPTION
## PR #59 不是「升級壞了」，是群組規則有個系統性的洞

`.github/dependabot.yml` 有一個叫 `pub-minor-and-patch` 的群組，設定是
`update-types: ['minor', 'patch']`，檔案裡的註釋寫著「Major bumps stay ungrouped:
they need their own PR because each one can carry breaking changes」。

**但 dependabot 是依版號位置分類的。** 對 0.x 套件，它把 `0.9 → 0.10` 叫 *minor*。
pub 不是這樣算的：`^0.9.40` **不接受** 0.10，那是破壞性變更。

於是 PR #59 這個叫「minor-and-patch」的 PR 裡藏了**五個**破壞性升級：

| 套件 | 升級 | 是什麼 |
|---|---|---|
| `just_audio` | 0.9.46 → 0.10.6 | Android 音訊後端 |
| `audio_session` | 0.1.25 → 0.2.4 | 音訊焦點（just_audio 的相依） |
| `tray_manager` | 0.2.4 → 0.5.3 | 系統匣 |
| `window_manager` | 0.4.3 → 0.5.2 | 視窗管理 |
| `inno_bundle` | 0.11.2 → 0.12.0 | Windows 安裝檔打包 |

`just_audio` 那一個當場就把 CI 弄紅了（`ConcatenatingAudioSource` 在 0.10 標成
deprecated → `flutter analyze` exit 1）。另外四個沒有靜態訊號，會靜靜合進去。

> `05-roadmap.md` 的 D4 還記著：just_audio 0.10.x 有 open issue #1486，**release
> build 沒有聲音**。這種東西不該搭順風車。

## 做法

12 個仍在 0.x 的直接依賴逐一列進 `exclude-patterns`（該鍵優先於 `patterns`），
讓它們各自成為一個可審的 PR。

清單會隨著套件各自走到 1.0 而漂移，所以配一條靜態規則
（`test/workflows/dependabot_group_static_rule_test.dart`）**雙向**守著：

- 新增一個 0.x 依賴卻忘了排除 → 紅
- 排除了一個已經離開 0.x 的套件 → 紅

兩個方向都實測過會紅（刪掉 `just_audio` 那筆、以及塞一個 `dio` 進去）。另外兩條
測試餵合成的 pubspec / dependabot 設定給解析函式，確認它不會把 `sdk:` 或 `hosted:`
的條目誤判成版本。

## 順帶查清楚的：另外兩個紅的 PR 跟升級無關

| PR | 紅的原因 |
|---|---|
| #60 go_router 14→18 | `audio_controller_phase1_test` 的 `superseded source error without next track does not stop newer request` |
| #61 package_info_plus 8→9 | **同一條測試** |

那正是 issue #43 的抖動，**已經在 `26715929` 修掉**（那三個紅的跑都在
2026-09-07 11:09–12:21 UTC，抖動修好是 2026-09-08 00:46 UTC）。這兩個 PR 要 rebase
之後重看，現有的紅沒有證據價值。

## 驗收

| 項目 | 結果 |
|---|---|
| 完整套件 | **1514 passed**（+4 是新規則測試自己） |
| YAML 合法性 | `yaml.safe_load` 解得出來，群組有 `patterns` / `exclude-patterns` / `update-types` 三個鍵 |
| 規則武裝 | 兩個方向各種一個違規，都紅 |
| `dart format` | 579 檔 0 diff |

**不需要實機驗證** —— 設定與測試改動，無 user-visible 行為變更。
