### PR TITLE
chore(deps): sync the lockfile sdk floor after the upgrades

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1660,4 +1660,4 @@ packages:
     version: "3.1.0"
 sdks:
   dart: ">=3.12.0 <4.0.0"
-  flutter: ">=3.38.4"
+  flutter: ">=3.44.0"


### PR DESCRIPTION
合併 #60 與 #63 之後，`main` 上跑一次 `flutter pub get` 會改寫 `pubspec.lock`：

```diff
 sdks:
   dart: ">=3.12.0 <4.0.0"
-  flutter: ">=3.38.4"
+  flutter: ">=3.44.0"
```

go_router 18 與 cached_network_image 4 都要求 Flutter ≥ 3.44，但兩個 dependabot PR 是**各自獨立解析**的，所以沒有任何一個的 lockfile 記到合併之後的下限。

repo 特地把 `pubspec.lock` 進版控（`2b80353b` "ensure reproducible builds"），而一個跑一次 `pub get` 就會被改寫的 lockfile 不具備那個性質——它還**低報**了 Flutter 下限，用 3.40 的人會在解析階段拿到不一樣的結果，而不是一開始就被擋下來。

三個升級疊在一起的樹在合併前已於本地驗過：`pub get` 解得開、`build_runner` + `slang` 正常、`flutter analyze` 乾淨、完整套件 1513 passed。這個 PR 只補上那一行。