### PR TITLE
fix(account): survive a credential store that cannot be read

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -196,8 +196,9 @@ the one intentional exception.
 
 ```text
 lib/core/                  Logger, ToastService, image loading/cache services,
-                           UI constants, breakpoints, shared utils (thumbnail
-                           URLs, Netease crypto, platform checks)
+                           guarded secure key/value store, UI constants,
+                           breakpoints, shared utils (thumbnail URLs, Netease
+                           crypto, platform checks)
 lib/services/audio/        AudioController, playback backends, queue, stream handoff
 lib/services/download/     Download scheduling, paths, source-aware media headers
 lib/services/media/        MediaHandoff — the byte-request header/redirect seam

--- a/lib/core/secure_key_value_store.dart
+++ b/lib/core/secure_key_value_store.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+
+/// 平台憑證儲存本身無法存取。
+///
+/// 這與「沒有存過東西」是兩件事：`read` 回 `null` 代表沒有憑證，這個例外代表
+/// 憑證可能存在但讀不出來。Android 的 Keystore 在裝置備份還原、系統更新或
+/// Keystore 損毀之後可能解不開既有密文；Windows 的 DPAPI 密文綁在使用者設定檔
+/// 上，設定檔重建或資料被搬到另一個帳號之後就解不開。
+///
+/// 兩者必須分開：把存取失敗當成「未登入」，使用者會看到 app 壞掉的樣子而不是
+/// 一個可解釋的狀態。
+class SecureStorageUnavailable implements Exception {
+  const SecureStorageUnavailable(this.operation, this.code);
+
+  /// `read` / `write` / `delete`。
+  final String operation;
+
+  /// 平台回報的錯誤碼。**只帶碼不帶 message** —— 平台訊息可能夾帶金鑰別名或
+  /// 檔案路徑，而 `AppLogger` 的規則是憑證相關失敗只寫固定的消毒訊息。
+  final String? code;
+
+  @override
+  String toString() =>
+      'SecureStorageUnavailable($operation'
+      '${code == null ? '' : ', code=$code'})';
+}
+
+/// 憑證儲存的窄介面。
+///
+/// 存在的理由有兩個：測試不必碰平台通道，以及所有平台例外都在一個地方轉成
+/// [SecureStorageUnavailable]，不會有哪個呼叫端漏接。
+abstract class SecureKeyValueStore {
+  Future<String?> read({required String key});
+
+  Future<void> write({required String key, required String value});
+
+  Future<void> delete({required String key});
+}
+
+class FlutterSecureKeyValueStore implements SecureKeyValueStore {
+  FlutterSecureKeyValueStore({FlutterSecureStorage? storage})
+    : _storage = storage ?? const FlutterSecureStorage();
+
+  final FlutterSecureStorage _storage;
+
+  @override
+  Future<String?> read({required String key}) =>
+      _guard('read', () => _storage.read(key: key));
+
+  @override
+  Future<void> write({required String key, required String value}) {
+    return _guard('write', () => _storage.write(key: key, value: value));
+  }
+
+  @override
+  Future<void> delete({required String key}) =>
+      _guard('delete', () => _storage.delete(key: key));
+
+  Future<T> _guard<T>(String operation, Future<T> Function() body) async {
+    try {
+      return await body();
+    } on PlatformException catch (error) {
+      throw SecureStorageUnavailable(operation, error.code);
+    } on MissingPluginException {
+      throw SecureStorageUnavailable(operation, 'missing_plugin');
+    }
+  }
+}

--- a/lib/services/AGENTS.md
+++ b/lib/services/AGENTS.md
@@ -129,6 +129,18 @@ Credential parse/load failures must log fixed sanitized messages only. Do not
 pass raw secure-storage JSON, cookie strings, token-bearing exceptions, or
 `FormatException` source snippets into `AppLogger`.
 
+All three services reach secure storage through `SecureKeyValueStore`
+(`lib/core/secure_key_value_store.dart`), never `FlutterSecureStorage` directly.
+The wrapper turns platform failures into `SecureStorageUnavailable`, carrying
+the operation and the platform code but not its message, which can name a key
+alias or a path. **"Cannot read the credential" is not "there is no
+credential":** Android Keystore can fail to decrypt after a device restore and
+Windows DPAPI after a profile is rebuilt. `_loadCredentials` degrades to logged
+out and logs a fixed message rather than letting the exception out --
+`SourceAuthContext` and both Dio interceptors sit on that path, so an escaping
+exception turns every API request into an error. It does not latch: a transient
+Keystore failure is retried on the next call.
+
 Bilibili medal wall radio import keeps credential ownership in
 `BilibiliAccountService`, but live room lookup and `getRoomInfoOld` handling
 belong in `BilibiliLiveClient`.

--- a/lib/services/account/bilibili_account_service.dart
+++ b/lib/services/account/bilibili_account_service.dart
@@ -3,7 +3,7 @@ import 'dart:convert';
 
 import 'package:dio/dio.dart';
 import 'package:flutter_inappwebview/flutter_inappwebview.dart';
-import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:fmp/core/secure_key_value_store.dart';
 import 'package:isar_community/isar.dart';
 
 import 'package:fmp/core/logger.dart';
@@ -66,7 +66,7 @@ class QrCodePollResult {
 class BilibiliAccountService extends AccountService with Logging {
   final Dio _dio;
   final BilibiliLiveClient _liveClient;
-  final FlutterSecureStorage _secureStorage;
+  final SecureKeyValueStore _secureStorage;
   final AccountRepository _accounts;
   BilibiliCredentials? _cachedCredentials;
 
@@ -74,11 +74,14 @@ class BilibiliAccountService extends AccountService with Logging {
   static const String _apiBase = 'https://api.bilibili.com';
   static const String _passportBase = 'https://passport.bilibili.com';
 
-  BilibiliAccountService({required Isar isar, BilibiliLiveClient? liveClient})
-    : _accounts = AccountRepository(isar),
-      _secureStorage = const FlutterSecureStorage(),
-      _dio = SourceHttpPolicy.createApiDio(SourceIds.bilibili),
-      _liveClient = liveClient ?? BilibiliLiveClient();
+  BilibiliAccountService({
+    required Isar isar,
+    BilibiliLiveClient? liveClient,
+    SecureKeyValueStore? secureStorage,
+  }) : _accounts = AccountRepository(isar),
+       _secureStorage = secureStorage ?? FlutterSecureKeyValueStore(),
+       _dio = SourceHttpPolicy.createApiDio(SourceIds.bilibili),
+       _liveClient = liveClient ?? BilibiliLiveClient();
 
   @override
   String get platform => SourceIds.bilibili;
@@ -531,7 +534,17 @@ class BilibiliAccountService extends AccountService with Logging {
   /// 從 secure storage 加載憑據（帶內存緩存）
   Future<BilibiliCredentials?> _loadCredentials() async {
     if (_cachedCredentials != null) return _cachedCredentials;
-    final json = await _secureStorage.read(key: _storageKey);
+    final String? json;
+    try {
+      json = await _secureStorage.read(key: _storageKey);
+    } on SecureStorageUnavailable catch (error) {
+      // 「讀不到憑證」與「沒有憑證」是兩回事，但呼叫端要的是一個能繼續走的答案，
+      // 而且這條路徑會被播放與啟動流程碰到 —— 往上丟會讓 provider 進 error state。
+      // 降級成未登入，真正的原因寫進固定訊息的 log（憑證相關的 log 只寫消毒過的
+      // 內容，見 lib/services/AGENTS.md）。不設已載入旗標，讓暫時性失敗還能復原。
+      logWarning('Bilibili credential store unavailable: $error');
+      return null;
+    }
     if (json == null) return null;
     try {
       _cachedCredentials = BilibiliCredentials.fromJson(

--- a/lib/services/account/netease_account_service.dart
+++ b/lib/services/account/netease_account_service.dart
@@ -3,7 +3,7 @@ import 'dart:convert';
 
 import 'package:dio/dio.dart';
 import 'package:flutter_inappwebview/flutter_inappwebview.dart';
-import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:fmp/core/secure_key_value_store.dart';
 import 'package:isar_community/isar.dart';
 
 import 'package:fmp/core/logger.dart';
@@ -22,7 +22,7 @@ import 'package:fmp/data/repositories/account_repository.dart';
 /// MUSIC_U 有效期長（~1 年），無需刷新流程。
 class NeteaseAccountService extends AccountService with Logging {
   final Dio _dio;
-  final FlutterSecureStorage _secureStorage;
+  final SecureKeyValueStore _secureStorage;
   final AccountRepository _accounts;
   NeteaseCredentials? _cachedCredentials;
   bool _credentialsLoaded = false;
@@ -38,14 +38,16 @@ class NeteaseAccountService extends AccountService with Logging {
       'os=pc; osver=Microsoft-Windows-10-Professional-build-10586-64bit; '
       'appver=2.7.1.198277; channel=netease; __csrf=; MUSIC_U=';
 
-  NeteaseAccountService({required Isar isar})
-    : _accounts = AccountRepository(isar),
-      _secureStorage = const FlutterSecureStorage(),
-      _dio = SourceHttpPolicy.createApiDio(
-        SourceIds.netease,
-        extraHeaders: const {'Cookie': _anonymousCookie},
-        contentType: Headers.formUrlEncodedContentType,
-      );
+  NeteaseAccountService({
+    required Isar isar,
+    SecureKeyValueStore? secureStorage,
+  }) : _accounts = AccountRepository(isar),
+       _secureStorage = secureStorage ?? FlutterSecureKeyValueStore(),
+       _dio = SourceHttpPolicy.createApiDio(
+         SourceIds.netease,
+         extraHeaders: const {'Cookie': _anonymousCookie},
+         contentType: Headers.formUrlEncodedContentType,
+       );
 
   @override
   String get platform => SourceIds.netease;
@@ -388,7 +390,17 @@ class NeteaseAccountService extends AccountService with Logging {
   /// 從 secure storage 加載憑據（帶內存緩存）
   Future<NeteaseCredentials?> _loadCredentials() async {
     if (_credentialsLoaded) return _cachedCredentials;
-    final json = await _secureStorage.read(key: _storageKey);
+    final String? json;
+    try {
+      json = await _secureStorage.read(key: _storageKey);
+    } on SecureStorageUnavailable catch (error) {
+      // 「讀不到憑證」與「沒有憑證」是兩回事，但呼叫端要的是一個能繼續走的答案，
+      // 而且這條路徑會被播放與啟動流程碰到 —— 往上丟會讓 provider 進 error state。
+      // 降級成未登入，真正的原因寫進固定訊息的 log（憑證相關的 log 只寫消毒過的
+      // 內容，見 lib/services/AGENTS.md）。不設已載入旗標，讓暫時性失敗還能復原。
+      logWarning('Netease credential store unavailable: $error');
+      return null;
+    }
     if (json == null) {
       _credentialsLoaded = true;
       return null;
@@ -446,7 +458,19 @@ class NeteaseAccountService extends AccountService with Logging {
   }
 
   Future<_LoginSnapshot> _captureLoginSnapshot() async {
-    final storedJson = await _secureStorage.read(key: _storageKey);
+    final String? storedJson;
+    try {
+      storedJson = await _secureStorage.read(key: _storageKey);
+    } on SecureStorageUnavailable catch (error) {
+      // 快照拿不到就等於沒有可還原的登入狀態；記下來，否則「重新登入失敗後
+      // 沒有還原」會看起來像是還原邏輯壞了。
+      logWarning('Netease credential store unavailable: $error');
+      return const _LoginSnapshot(
+        credentialsJson: null,
+        credentials: null,
+        account: null,
+      );
+    }
     NeteaseCredentials? credentials;
     String? credentialsJson;
     if (storedJson != null) {

--- a/lib/services/account/youtube_account_service.dart
+++ b/lib/services/account/youtube_account_service.dart
@@ -2,7 +2,7 @@ import 'dart:convert';
 
 import 'package:dio/dio.dart';
 import 'package:flutter_inappwebview/flutter_inappwebview.dart';
-import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:fmp/core/secure_key_value_store.dart';
 import 'package:isar_community/isar.dart';
 
 import 'package:fmp/core/logger.dart';
@@ -20,7 +20,7 @@ import 'package:fmp/data/repositories/account_repository.dart';
 /// Cookie 有效期 ~2 年，無需刷新流程。
 class YouTubeAccountService extends AccountService with Logging {
   final Dio _dio;
-  final FlutterSecureStorage _secureStorage;
+  final SecureKeyValueStore _secureStorage;
   final AccountRepository _accounts;
   YouTubeCredentials? _cachedCredentials;
 
@@ -37,13 +37,15 @@ class YouTubeAccountService extends AccountService with Logging {
     '__Secure-3PSID',
   };
 
-  YouTubeAccountService({required Isar isar})
-    : _accounts = AccountRepository(isar),
-      _secureStorage = const FlutterSecureStorage(),
-      _dio = SourceHttpPolicy.createApiDio(
-        SourceIds.youtube,
-        contentType: 'application/json',
-      );
+  YouTubeAccountService({
+    required Isar isar,
+    SecureKeyValueStore? secureStorage,
+  }) : _accounts = AccountRepository(isar),
+       _secureStorage = secureStorage ?? FlutterSecureKeyValueStore(),
+       _dio = SourceHttpPolicy.createApiDio(
+         SourceIds.youtube,
+         contentType: 'application/json',
+       );
 
   @override
   String get platform => SourceIds.youtube;
@@ -519,7 +521,17 @@ class YouTubeAccountService extends AccountService with Logging {
 
   Future<YouTubeCredentials?> _loadCredentials() async {
     if (_cachedCredentials != null) return _cachedCredentials;
-    final json = await _secureStorage.read(key: _storageKey);
+    final String? json;
+    try {
+      json = await _secureStorage.read(key: _storageKey);
+    } on SecureStorageUnavailable catch (error) {
+      // 「讀不到憑證」與「沒有憑證」是兩回事，但呼叫端要的是一個能繼續走的答案，
+      // 而且這條路徑會被播放與啟動流程碰到 —— 往上丟會讓 provider 進 error state。
+      // 降級成未登入，真正的原因寫進固定訊息的 log（憑證相關的 log 只寫消毒過的
+      // 內容，見 lib/services/AGENTS.md）。不設已載入旗標，讓暫時性失敗還能復原。
+      logWarning('YouTube credential store unavailable: $error');
+      return null;
+    }
     if (json == null) return null;
     try {
       _cachedCredentials = YouTubeCredentials.fromJson(

--- a/lib/services/lyrics/lyrics_ai_config_service.dart
+++ b/lib/services/lyrics/lyrics_ai_config_service.dart
@@ -1,33 +1,6 @@
-import 'package:flutter_secure_storage/flutter_secure_storage.dart';
-
 import 'package:fmp/core/constants/app_constants.dart';
+import 'package:fmp/core/secure_key_value_store.dart';
 import 'package:fmp/data/models/settings.dart';
-
-abstract class SecureKeyValueStore {
-  Future<String?> read({required String key});
-
-  Future<void> write({required String key, required String value});
-
-  Future<void> delete({required String key});
-}
-
-class FlutterSecureKeyValueStore implements SecureKeyValueStore {
-  FlutterSecureKeyValueStore({FlutterSecureStorage? storage})
-    : _storage = storage ?? const FlutterSecureStorage();
-
-  final FlutterSecureStorage _storage;
-
-  @override
-  Future<String?> read({required String key}) => _storage.read(key: key);
-
-  @override
-  Future<void> write({required String key, required String value}) {
-    return _storage.write(key: key, value: value);
-  }
-
-  @override
-  Future<void> delete({required String key}) => _storage.delete(key: key);
-}
 
 class LyricsAiConfig {
   const LyricsAiConfig({

--- a/test/services/account/account_secure_storage_failure_test.dart
+++ b/test/services/account/account_secure_storage_failure_test.dart
@@ -1,0 +1,106 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fmp/core/logger.dart';
+import 'package:fmp/core/secure_key_value_store.dart';
+import 'package:fmp/data/models/account.dart';
+import 'package:fmp/services/account/bilibili_account_service.dart';
+import 'package:fmp/services/account/netease_account_service.dart';
+import 'package:fmp/services/account/youtube_account_service.dart';
+import 'package:isar_community/isar.dart';
+
+import '../../support/fakes/fake_secure_key_value_store.dart';
+import '../../support/isar_test_harness.dart';
+
+/// 憑證儲存本身壞掉時（Android Keystore 解不開既有密文、Windows DPAPI 換了使用者
+/// 設定檔），`read()` 丟的是 `PlatformException` 而不是回 `null`。
+///
+/// 這條路徑被 `SourceAuthContext`（串流解析 / 播放交接 / 下載 / 曲目詳情的授權閘）
+/// 與兩個 Dio interceptor 使用，所以往上丟等於每一個 API 請求都變成錯誤。降級成
+/// 「未登入」才是可以繼續走的答案。
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory tempDir;
+  late Isar isar;
+
+  setUpAll(() async {
+    await initializeIsarForTests();
+  });
+
+  setUp(() async {
+    AppLogger.clearLogs();
+    tempDir = await Directory.systemTemp.createTemp(
+      'account_secure_storage_failure_test_',
+    );
+    isar = await Isar.open(
+      [AccountSchema],
+      directory: tempDir.path,
+      name: 'account_secure_storage_failure_test',
+    );
+  });
+
+  tearDown(() async {
+    AppLogger.clearLogs();
+    await isar.close(deleteFromDisk: true);
+    if (await tempDir.exists()) {
+      await tempDir.delete(recursive: true);
+    }
+  });
+
+  test('an unreadable Bilibili credential store reads as logged out', () async {
+    final service = BilibiliAccountService(
+      isar: isar,
+      secureStorage: UnavailableSecureKeyValueStore(),
+    );
+
+    expect(await service.getAuthCookieString(), isNull);
+    expect(_allLogText(), contains('Bilibili credential store unavailable'));
+  });
+
+  test('an unreadable YouTube credential store reads as logged out', () async {
+    final service = YouTubeAccountService(
+      isar: isar,
+      secureStorage: UnavailableSecureKeyValueStore(),
+    );
+
+    expect(await service.getAuthHeaders(), isNull);
+    expect(_allLogText(), contains('YouTube credential store unavailable'));
+  });
+
+  test('an unreadable Netease credential store reads as logged out', () async {
+    final service = NeteaseAccountService(
+      isar: isar,
+      secureStorage: UnavailableSecureKeyValueStore(),
+    );
+
+    expect(await service.getAuthCookieString(), isNull);
+    expect(_allLogText(), contains('Netease credential store unavailable'));
+  });
+
+  test(
+    'the failure is retried rather than cached as "no credentials"',
+    () async {
+      final store = UnavailableSecureKeyValueStore();
+      final service = NeteaseAccountService(isar: isar, secureStorage: store);
+
+      await service.getAuthCookieString();
+      await service.getAuthCookieString();
+
+      // 一次暫時性的 Keystore 失敗不該把整個 app 生命週期釘在「未登入」。
+      expect(store.readCount, 2);
+    },
+  );
+
+  test('the log carries the operation and code, not the platform message', () {
+    const failure = SecureStorageUnavailable('read', 'decrypt_failed');
+
+    expect(
+      failure.toString(),
+      'SecureStorageUnavailable(read, code=decrypt_failed)',
+    );
+  });
+}
+
+String _allLogText() =>
+    AppLogger.logs.map((entry) => entry.toString()).join('\n');

--- a/test/services/lyrics/lyrics_ai_config_service_test.dart
+++ b/test/services/lyrics/lyrics_ai_config_service_test.dart
@@ -2,12 +2,14 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:fmp/data/models/settings.dart';
 import 'package:fmp/services/lyrics/lyrics_ai_config_service.dart';
 
+import '../../support/fakes/fake_secure_key_value_store.dart';
+
 void main() {
   group('LyricsAiConfigService', () {
     test('uses unavailable off mode by default', () async {
       final service = LyricsAiConfigService(
         loadSettings: () async => Settings(),
-        secureStorage: _MemorySecureKeyValueStore(),
+        secureStorage: MemorySecureKeyValueStore(),
       );
 
       final config = await service.loadConfig();
@@ -22,7 +24,7 @@ void main() {
         ..lyricsAiEndpoint = 'https://api.example.com/v1'
         ..lyricsAiModel = 'gpt-test'
         ..lyricsAiTimeoutSeconds = 10;
-      final storage = _MemorySecureKeyValueStore({'lyrics_ai_api_key': 'key'});
+      final storage = MemorySecureKeyValueStore({'lyrics_ai_api_key': 'key'});
       final service = LyricsAiConfigService(
         loadSettings: () async => settings,
         secureStorage: storage,
@@ -40,9 +42,7 @@ void main() {
         ..lyricsAiEndpoint = ' https://api.example.com/v1 '
         ..lyricsAiModel = ' gpt-test '
         ..lyricsAiTimeoutSeconds = 15;
-      final storage = _MemorySecureKeyValueStore({
-        'lyrics_ai_api_key': ' key ',
-      });
+      final storage = MemorySecureKeyValueStore({'lyrics_ai_api_key': ' key '});
       final service = LyricsAiConfigService(
         loadSettings: () async => settings,
         secureStorage: storage,
@@ -63,7 +63,7 @@ void main() {
           ..lyricsAiTitleParsingMode = LyricsAiTitleParsingMode.advancedAiSelect
           ..lyricsAiEndpoint = 'https://example.test/v1'
           ..lyricsAiModel = 'test-model',
-        secureStorage: _MemorySecureKeyValueStore({'lyrics_ai_api_key': 'key'}),
+        secureStorage: MemorySecureKeyValueStore({'lyrics_ai_api_key': 'key'}),
       );
 
       final config = await service.loadConfig();
@@ -80,7 +80,7 @@ void main() {
         ..lyricsAiTimeoutSeconds = 0;
       final service = LyricsAiConfigService(
         loadSettings: () async => settings,
-        secureStorage: _MemorySecureKeyValueStore({'lyrics_ai_api_key': 'key'}),
+        secureStorage: MemorySecureKeyValueStore({'lyrics_ai_api_key': 'key'}),
       );
 
       final config = await service.loadConfig();
@@ -89,7 +89,7 @@ void main() {
     });
 
     test('stores trimmed key and clears key on empty', () async {
-      final storage = _MemorySecureKeyValueStore();
+      final storage = MemorySecureKeyValueStore();
       final service = LyricsAiConfigService(
         loadSettings: () async => Settings(),
         secureStorage: storage,
@@ -104,24 +104,4 @@ void main() {
       expect(await service.readApiKey(), '');
     });
   });
-}
-
-class _MemorySecureKeyValueStore implements SecureKeyValueStore {
-  _MemorySecureKeyValueStore([Map<String, String>? initialValues])
-    : values = Map<String, String>.from(initialValues ?? const {});
-
-  final Map<String, String> values;
-
-  @override
-  Future<String?> read({required String key}) async => values[key];
-
-  @override
-  Future<void> write({required String key, required String value}) async {
-    values[key] = value;
-  }
-
-  @override
-  Future<void> delete({required String key}) async {
-    values.remove(key);
-  }
 }

--- a/test/support/fakes/fake_secure_key_value_store.dart
+++ b/test/support/fakes/fake_secure_key_value_store.dart
@@ -1,0 +1,51 @@
+import 'package:fmp/core/secure_key_value_store.dart';
+
+/// 記憶體版的憑證儲存。
+class MemorySecureKeyValueStore implements SecureKeyValueStore {
+  MemorySecureKeyValueStore([Map<String, String>? initialValues])
+    : values = Map<String, String>.from(initialValues ?? const {});
+
+  final Map<String, String> values;
+
+  @override
+  Future<String?> read({required String key}) async => values[key];
+
+  @override
+  Future<void> write({required String key, required String value}) async {
+    values[key] = value;
+  }
+
+  @override
+  Future<void> delete({required String key}) async {
+    values.remove(key);
+  }
+}
+
+/// 每次操作都以 [SecureStorageUnavailable] 失敗的憑證儲存。
+///
+/// 模擬 Android Keystore 解不開既有密文、或 Windows DPAPI 換了使用者設定檔的
+/// 情形 —— 那些在平台層是 `PlatformException`，不是回 `null`。
+class UnavailableSecureKeyValueStore implements SecureKeyValueStore {
+  UnavailableSecureKeyValueStore({this.code = 'decrypt_failed'});
+
+  final String code;
+
+  /// 被呼叫過幾次，讓測試能斷言「失敗之後沒有被當成已載入而不再重試」。
+  int readCount = 0;
+
+  @override
+  Future<String?> read({required String key}) async {
+    readCount++;
+    throw SecureStorageUnavailable('read', code);
+  }
+
+  @override
+  Future<void> write({required String key, required String value}) async {
+    throw SecureStorageUnavailable('write', code);
+  }
+
+  @override
+  Future<void> delete({required String key}) async {
+    throw SecureStorageUnavailable('delete', code);
+  }
+}


### PR DESCRIPTION
關掉 #35。

三個帳號 service 的 `_secureStorage.read()` 都在 `try` **之外**——那個 `try` 只包 `jsonDecode`：

```dart
final json = await _secureStorage.read(key: _storageKey);   // 沒有保護
if (json == null) return null;
try {
  _cachedCredentials = XxxCredentials.fromJson(jsonDecode(json) ...);
```

`read()` 走 MethodChannel 打到平台實作，平台側失敗回來的是 `PlatformException` 而**不是 `null`**：Android Keystore 在裝置備份還原或系統更新後可能解不開既有密文，Windows DPAPI 的密文綁在使用者設定檔上。

## 影響比 issue 寫的廣

issue 說「帳號相關路徑整條炸掉」。實際的消費者是：

- **`SourceAuthContext`**（`:44` / `:50` / `:52`）—— 串流解析、播放交接、下載、曲目詳情的授權閘
- **`netease_auth_interceptor` 與 `youtube_auth_interceptor`** —— Dio interceptor，**每一個 API 請求**都會經過

所以未接的例外不是「帳號頁壞掉」，是每個請求都變成錯誤。

> 順帶更正 issue 的一處：`isLoggedIn()` 讀的是 Isar（`getCurrentAccount()`），不碰 secure storage，所以 `accountCookieRefreshProvider` 不在這條路徑上。真正踩到的是 `getAuthCookieString` / `getAuthHeaders` / `getCsrfToken`。

## 做法

`SecureKeyValueStore` 這個接縫**本來就有**，只是住在 `lyrics_ai_config_service.dart` 裡面。把它搬到 `lib/core/secure_key_value_store.dart`，變成唯一入口，平台例外在那一層統一轉成 `SecureStorageUnavailable`。

三個關鍵決定：

1. **例外只帶 operation 與平台 code，不帶 message。** 平台訊息可能夾帶金鑰別名或檔案路徑，而 `lib/services/AGENTS.md` 的規則是憑證相關失敗只寫固定的消毒訊息。
2. **降級成「未登入」而不是往上丟。** 呼叫端要的是一個能繼續走的答案；真正的原因寫進固定訊息的 log。
3. **失敗不 latch。** 不設「已載入」旗標，一次暫時性的 Keystore 失敗不該把整個 app 生命週期釘在未登入。有測試守著（`readCount == 2`）。

三個 service 同時補上可注入的 store——**沒有它這個失敗根本測不到**，這也是為什麼這個缺陷一直沒有測試。

## 沒做的

- **沒有加「憑證存取失敗」的持久化欄位。** `Account` 是 Isar collection，加欄位等於 schema 變更加 migration，而這是暫時的裝置狀態不該持久化。
- **沒有做 UI 呈現。** 那是 #36（統一三源失效呈現）的範圍，而 #36 要呈現的正是這個 PR 建立的區分。
- **`write()` / `delete()` 維持往上丟**（現在是型別化的例外，不再是裸 `PlatformException`）。那些是使用者主動觸發、有 UI 回饋的路徑，失敗就該讓使用者知道。

## 驗收

| 項目 | 結果 |
|---|---|
| 完整套件 | **1518 passed**（+5 是新測試） |
| `flutter analyze` | 乾淨 |
| `dart format lib test` | 582 檔 0 diff |
| 反向驗證 | 把 bilibili 的守衛拆掉，測試立刻紅在未捕捉的 `SecureStorageUnavailable` 上 |

**不需要實機驗證** —— 這個 PR 只是把一個未捕捉的例外變成降級路徑，沒有 user-visible 的行為變更（失敗時的畫面本來就是「未登入」，差別在於現在不會炸）。**下一步的 #62（flutter_secure_storage 9→10）才需要實機**：它換掉 Android 的預設 cipher，而這個 PR 正是它失敗時的安全網。
