### PR TITLE
docs(agents): record why v10 secure storage cannot be skipped

### DIFF
--- a/lib/services/AGENTS.md
+++ b/lib/services/AGENTS.md
@@ -141,6 +141,17 @@ out and logs a fixed message rather than letting the exception out --
 exception turns every API request into an error. It does not latch: a transient
 Keystore failure is retried on the next call.
 
+FMP pins `flutter_secure_storage` to 10.x. v10 re-encrypts Android credentials
+on first read -- key cipher to `RSA_ECB_OAEPwithSHA_256andMGF1Padding`, storage
+cipher to `AES_GCM_NoPadding` -- and 11.x removes the 9.x ciphers it migrates
+from. **A bump to 11.x is a release-sequencing decision, not a routine version
+bump.** A user who never runs a shipped 10.x build loses their stored
+credentials on reaching 11.x, and FMP updates in-app in a way that lets users
+skip versions, so "10.x was released once" is not "every install has migrated".
+It degrades to a forced re-login rather than a crash only because of the
+`SecureKeyValueStore` guard above. Upstream is explicit: "If you used a version
+prior to v10, upgrade to v10 first so existing data is migrated."
+
 Bilibili medal wall radio import keeps credential ownership in
 `BilibiliAccountService`, but live room lookup and `getRoomInfoOld` handling
 belong in `BilibiliLiveClient`.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -65,7 +65,9 @@ dependencies:
   # 帐号管理
   flutter_inappwebview: ^6.1.5   # WebView 登录（WebView2 on Windows）
   qr_flutter: ^4.1.0             # QR 码生成（备选登录方式）
-  flutter_secure_storage: ^10.3.1  # Cookie/Token 安全存储
+  # 升到 11.x 之前先讀 lib/services/AGENTS.md 的 Account System 一節：
+  # v10 是憑證遷移的必經踏腳石，跳過會讓既有使用者的憑證讀不出來。
+  flutter_secure_storage: ^10.3.1  # Cookie/Token 安全儲存
   pointycastle: ^3.9.1           # RSA 加密（Cookie 刷新流程）
 
   # 工具


### PR DESCRIPTION
`flutter_secure_storage` 剛從 9.2.4 升到 10.3.1（#62）。**11.0.0 已經發布了**，
而它移除了 v10 用來遷移的舊 cipher。

## 為什麼這值得寫成規則

未來那個 v11 的 dependabot PR，diff 看起來會跟 #62 一模一樣 —— 一行版本號。
但它的後果完全不同：

| | 版號 diff | 對既有使用者 |
|---|---|---|
| 9.2.4 → 10.3.1（#62） | 一行 | 首次讀取時自動重新加密，無感 |
| 10.x → 11.x | 一行 | **沒跑過 v10 版本的安裝，憑證直接讀不出來** |

upstream 的 changelog 寫得很明確：

> items deprecated in v10 have been removed. Any data saved using deprecated
> algorithms or features will be unusable after this upgrade. If you used a
> version prior to v10, upgrade to v10 first so existing data is migrated.

FMP 不是只有開發機 —— 已發布到 v1.9.1（2026-07-16），而且有 in-app updater
**允許使用者跳版**。所以「我們發過一次 v10」不等於「所有安裝都遷移過了」。
換句話說這不是相依升級，是**發版時序決策**：要先確定 v10 的版本真的被跑過，
才輪得到 v11。

失敗時降級成「被迫重新登入」而不是崩潰，靠的是 #35（PR #72）加的
`SecureKeyValueStore` 護欄 —— 這也是為什麼那條規則就寫在它旁邊。

## 改了什麼

- `lib/services/AGENTS.md` § Account System：規則正文接在
  `SecureKeyValueStore` 那段之後。
- `pubspec.yaml`：相依宣告上方一行指路。**這是重點** —— 未來的 bump PR 只會
  動到 `pubspec.yaml`，不會載入 `lib/services/AGENTS.md`，指路註釋是唯一
  一定會出現在該 PR diff 附近的位置。

依專案「一條規則只寫在一個檔案，其他地方交叉引用」的要求，只有這兩處。

## 驗證

純文檔 + 一個 YAML 註釋，零行為變更。

- `git diff --check` 乾淨
- `flutter pub get` 成功（證明 `pubspec.yaml` 仍解析得過），`pubspec.lock` 無變化

順帶查證但本輪未使用的事實：v11 把 plugin 的 `minSdk` 拉到 24、`compileSdk`
拉到 37。FMP 的 merged manifest 是 `minSdkVersion="24"`，所以將來那條不擋路。
