### PR TITLE
fix(ui): give the rail's settings entry its label back

### DIFF
--- a/lib/ui/layouts/responsive_scaffold.dart
+++ b/lib/ui/layouts/responsive_scaffold.dart
@@ -638,12 +638,44 @@ class _RailSettingsButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    // 圖示與文字自己畫：`labelType` 只作用在 `destinations` 上，碰不到
+    // `trailing`，所以放在這裡的東西不會自動長出標籤。尺寸、顏色與間距抄自
+    // Flutter 的 `_NavigationRailDefaultsM3`（圖示 24dp / onSurfaceVariant，
+    // 圖示與標籤相隔 4dp，標籤 labelMedium / onSurface），否則設定會是這一欄裡
+    // 唯一沒有文字、而且大小對不上的那一個。
     return Padding(
-      padding: const EdgeInsets.only(bottom: AppSpacing.sm),
-      child: IconButton(
-        icon: Icon(settingsDestination.icon),
-        onPressed: onPressed,
-        tooltip: settingsDestination.label,
+      padding: const EdgeInsets.only(bottom: AppSpacing.md),
+      child: InkWell(
+        onTap: onPressed,
+        customBorder: const StadiumBorder(),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(
+            horizontal: AppSpacing.sm,
+            vertical: AppSpacing.sm,
+          ),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(
+                settingsDestination.icon,
+                size: 24,
+                color: colorScheme.onSurfaceVariant,
+              ),
+              const SizedBox(height: AppSpacing.xs),
+              Text(
+                settingsDestination.label,
+                style: theme.textTheme.labelMedium?.copyWith(
+                  color: colorScheme.onSurface,
+                ),
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+              ),
+            ],
+          ),
+        ),
       ),
     );
   }


### PR DESCRIPTION
導覽軌底部的設定齒輪沒有文字，而它上面的五個目的地都有。

## 為什麼

`NavigationRail` 的 `labelType: NavigationRailLabelType.all` **只作用在
`destinations`**。`trailing` 收的是任意 widget，rail 不會替它套標籤或圖示主題。

設定自 `14c6608c`（M3 只允許 3–5 個目的地，FMP 有 6 個）起就不是導覽目的地，
住在 `trailing`，所以它是那一欄裡唯一沒有文字的一個 —— 標籤只以
`IconButton.tooltip` 的形式存在，觸控看不到，第一眼也看不到。

同一個 commit 的另外兩個設定入口都有文字（桌面側邊欄展開時的
`InkWell + Row(Icon, Text)`、compact 時 Home 頂端的按鈕），所以只有 rail 這一個突兀。

## 改了什麼

`_RailSettingsButton`（`responsive_scaffold.dart:634`）從 `IconButton` 換成
`InkWell` + `Column(Icon, 4dp, Text)`。數值抄自 Flutter SDK 的
`_NavigationRailDefaultsM3`，不是目測：

| 值 | 來源（`packages/flutter/lib/src/material/navigation_rail.dart`） |
|---|---|
| 圖示 24dp / `onSurfaceVariant` | `unselectedIconTheme`，`:1258-1262` |
| 圖示與標籤相隔 4dp | `_verticalIconLabelSpacingM3 = 4.0`，`:1180`（用 `AppSpacing.xs`） |
| 標籤 `labelMedium` / `onSurface` | `unselectedLabelTextStyle`，`:1250-1252` |

rail 寬 72dp（`AppLayout.railCollapsed`），標籤加了 `maxLines: 1` + ellipsis 防長翻譯撐破。

架構不變 —— 設定仍然不是 `NavigationRailDestination`，`lib/ui/AGENTS.md` 那段仍然正確。

## 驗證

- `flutter analyze` 乾淨
- `flutter test test/ui` 242 過
- **實機（Windows，改動後的 debug build）**：軌道現在是 首頁 / 搜尋 / 佇列 / 音樂庫 /
  電台 / **設定**，字級與間距與上面五個一致

> 擷圖過程的一個坑：`orca computer get-app-state --restore-window` 連續三次擷到別的
> 視窗（含我自己的終端），Win32 `SetForegroundWindow` 也被前景鎖定拒絕。最後用
> `PrintWindow` + `PW_RENDERFULLCONTENT` 對指定 HWND 直接取畫面才拿到正確畫面。

## 沒做的

**沒補 widget 測試。** 這條路徑要 pump `ResponsiveScaffold`，而它的
`bottomNavigationBar` 是 `_MiniPlayerSwitch`，會把整個 audio controller + Isar +
fake source 的 harness 拖進來（見 `mini_player_accessibility_test.dart` 的 28 行
import）。為一條標籤斷言建那套 harness，成本遠大於改動本身 —— 改用 AGENTS.md 對
UI 改動規定的實機驗證。要是之後有人為別的理由建了 scaffold 的 pump harness，
這條斷言應該補上去。
