### PR TITLE
fix(audio): make a concurrent initialize wait for the in-flight one

### DIFF
--- a/lib/services/audio/AGENTS.md
+++ b/lib/services/audio/AGENTS.md
@@ -73,6 +73,24 @@ mode, dropping the still-playing track into detached mode); those stay in
 deliberately left behind too — it starts playback, so it belongs with the
 transport commands, not with the queue mutations.
 
+## Initialization
+
+`build()` kicks initialization off with `Future.microtask(initialize)` and
+returns immediately, so **there is always a window where the controller exists
+but its stream subscriptions do not**. `initialize()` therefore shares one
+in-flight future: every caller — `_ensureInitialized()` before each operation, a
+re-run `build()`, a test's `setUp` — awaits the same completion.
+
+It used to be a `_isInitializing` boolean that returned early while the work was
+still in flight, which handed callers a already-completed future and let them
+proceed against a half-wired controller. The failure is silent and permanent
+rather than slow: `FmpAudioService`'s streams are **broadcast**, so an event
+emitted before `subscribe` is dropped and never replayed. That is what made
+`audio_controller_phase1_test` wait out its full `pumpUntil` budget on loaded CI
+machines (issue #43) while passing locally.
+
+A failed initialization clears the shared future so the next caller retries.
+
 ## Playback Side Effects
 
 Three things happen because a track started, not as part of starting it. All

--- a/lib/services/audio/audio_provider.dart
+++ b/lib/services/audio/audio_provider.dart
@@ -81,7 +81,6 @@ class AudioController extends Notifier<PlayerState>
 
   final List<StreamSubscription> _subscriptions = [];
   bool _isInitialized = false;
-  bool _isInitializing = false;
   bool _isDisposed = false;
 
   // 防止重複處理完成事件
@@ -204,9 +203,9 @@ class AudioController extends Notifier<PlayerState>
     _wireProviderCallbacks();
 
     ref.onDispose(_teardown);
-    // 起動初始化（非同步，但不阻塞）。每個操作前的 `_ensureInitialized`
-    // 會確保它完成；`_isInitialized` / `_isInitializing` 讓重跑的 build 不會
-    // 再跑一次。
+    // 起動初始化（非同步，但不阻塞）。每個操作前的 `_ensureInitialized` 會等到
+    // 它完成 —— [initialize] 共用同一個 in-flight future，所以重跑的 build 與
+    // 那些呼叫者都接到同一次初始化，不會重跑、也不會提早返回。
     Future.microtask(initialize);
 
     return const PlayerState();
@@ -332,11 +331,26 @@ class AudioController extends Notifier<PlayerState>
   /// 是否已初始化
   bool get isInitialized => _isInitialized;
 
-  /// 初始化
-  Future<void> initialize() async {
-    if (_isDisposed || _isInitialized || _isInitializing) return;
-    _isInitializing = true;
+  /// 初始化。同一次只跑一次，而且**每個呼叫者都等到它真的跑完**。
+  ///
+  /// 這裡曾經是 `if (_isInitializing) return;` —— 初始化還在飛的時候直接返回，
+  /// 呼叫端拿到一個立刻完成的 future，就當作已經初始化好了往下走。而 [build]
+  /// 用 `Future.microtask(initialize)` 起動，所以那個窗永遠存在：App 剛起來就
+  /// 按播放，[_ensureInitialized] 會落在窗裡，而下面的 `subscribe` 一行都還沒跑。
+  ///
+  /// 後果不是「慢一點」而是「事件永久消失」：`_audioService` 的那些串流是
+  /// broadcast，沒有 listener 時發射的事件會被直接丟掉、不補送。CI 上抓到的形狀
+  /// 是 `audio_controller_phase1_test` 的輸出裝置失敗永遠等不到 toast（issue #43
+  /// 的其中一條）。共用同一個 in-flight future 才是「等到好了」。
+  Future<void> initialize() {
+    if (_isDisposed || _isInitialized) return Future<void>.value();
+    return _initialization ??= _runInitialization();
+  }
 
+  /// 進行中的初始化。失敗時在 `finally` 清掉，讓下一次呼叫可以重試。
+  Future<void>? _initialization;
+
+  Future<void> _runInitialization() async {
     logInfo('Initializing AudioController...');
 
     try {
@@ -432,7 +446,9 @@ class AudioController extends Notifier<PlayerState>
       state = state.copyWith(error: 'Initialization failed: $e');
       rethrow;
     } finally {
-      _isInitializing = false;
+      // 沒走到 `_isInitialized = true`（拋了，或中途被 dispose）就把 in-flight
+      // 清掉，否則之後每個呼叫者都會拿到同一個失敗的 future，永遠不會重試。
+      if (!_isInitialized) _initialization = null;
     }
   }
 

--- a/test/services/audio/audio_controller_phase1_test.dart
+++ b/test/services/audio/audio_controller_phase1_test.dart
@@ -1117,6 +1117,66 @@ void main() {
       expect(audioService.pauseCallCount, greaterThan(0));
     });
 
+    // `initialize()` 的舊守衛是 `if (_isInitializing) return;` —— 初始化還在飛
+    // 的時候直接返回，呼叫端當作已經好了。`build()` 用
+    // `Future.microtask(initialize)` 起動，所以這個窗一直存在，而窗裡發射的
+    // endReasons 會被 broadcast 串流直接丟掉、不補送 —— 這就是 issue #43 在 CI
+    // 上「等 toast 等滿 5 秒」的來源。
+    test(
+      'a concurrent initialize waits for the in-flight one to wire up',
+      () async {
+        final settingsRepository = SettingsRepository(isar);
+        final trackRepository = TrackRepository(isar);
+        final queuePersistenceManager = QueuePersistenceManager(
+          queueRepository: queueRepository,
+          trackRepository: trackRepository,
+          settingsRepository: settingsRepository,
+        );
+        final audioStreamManager = _createAudioStreamManager(
+          trackRepository: trackRepository,
+          settingsRepository: settingsRepository,
+          sourceManager: sourceManager,
+        );
+        queueManager = QueueManager(
+          queueRepository: queueRepository,
+          trackRepository: trackRepository,
+          queuePersistenceManager: queuePersistenceManager,
+        );
+        audioService = FakeAudioService();
+        final localToastService = ToastService();
+        controller = buildTestAudioController(
+          audioService: audioService,
+          queueManager: queueManager,
+          audioStreamManager: audioStreamManager,
+          toastService: localToastService,
+          nowPlayingPublisher: testNowPlayingPublisher(),
+          settingsRepository: settingsRepository,
+          mixTracksFetcher: mixTracksFetcher.call,
+        );
+
+        final toasts = <ToastMessage>[];
+        final subscription = localToastService.messageStream.listen(toasts.add);
+        addTearDown(subscription.cancel);
+
+        // 讓 `build()` 排的 microtask 先起跑，重現「初始化已經在飛」的狀態。
+        // 少了這一行，下面就會是第一個呼叫者，測不到要測的東西。
+        await Future<void>.microtask(() {});
+        await controller.initialize();
+
+        // 這一行是整條斷言的重點：`initialize()` 返回之後，訂閱必須已經接上。
+        audioService.emitOutputDeviceFailure(
+          'Could not open/initialize audio device -> no sound.',
+        );
+        await pumpUntil(
+          () => toasts.isNotEmpty,
+          reason: 'the end reason emitted right after initialize must be heard',
+        );
+
+        expect(toasts, isNotEmpty);
+        expect(toasts.last.type, ToastType.error);
+      },
+    );
+
     // issue #41 症狀二：電台播放中 `_onPlaybackEnded` 整段早退，而
     // RadioController 從來沒有訂閱 endReasons —— 拔掉音效裝置完全沒有回饋。
     test('output device failure still reaches the user during radio', () async {


### PR DESCRIPTION
issue #43 那條 flake 的根因，而且它不是測試專有的問題 —— 是**啟動競態**。

## 這不是「負載讓它變慢」

`audio_controller_phase1_test` 在 CI 上逾時，時間永遠是整整 `0:00:05.000000`，
也就是 `pumpUntil` 的完整預算。而失敗那條測試的 log group 裡**沒有
`Audio output device failed:` 這一行** —— 它是 `_onOutputDeviceFailure` 的第一句
`logError`，跑了就一定留下。整份 CI log 裡這行只出現一次，但有**兩條**測試會發射
那個事件。

`_onPlaybackEnded` 除了 `if (_isDisposed) return;` 以外每條路徑都會留下 log 或呼叫
`_onOutputDeviceFailure`。所以結論只有一個：**那個事件根本沒有抵達 controller**。

## 根因

```dart
Future<void> initialize() async {
  if (_isDisposed || _isInitialized || _isInitializing) return;   // ← 不等 in-flight
  _isInitializing = true;
  await _audioService.initialize();      // 第一個 await
  await _queueManager.initialize();      // 第二個
  ...
  subscribe(_audioService.endReasons, _onPlaybackEnded);   // :370，兩個 await 之後
```

`build()`（`:210`）用 `Future.microtask(initialize)` 起動初始化並立刻返回。任何在那之後
呼叫 `initialize()` 的人 —— 每個操作前的 `_ensureInitialized()`、重跑的 `build()`、
測試的 `setUp` —— 只要撞上 `_isInitializing` 就拿到一個**立刻完成的 future**，然後
當作初始化好了往下走，而此時 `:370` 的 `subscribe` 還沒執行。

`FmpAudioService` 的那些串流是 **broadcast**：沒有 listener 時發射的事件會被直接
丟掉、**不補送**。所以失敗是無聲且永久的，不是慢。

**生產影響**：App 剛起來就按播放會落在同一個窗裡，操作跑在一個還沒接好訂閱的
controller 上。

## 改了什麼

`initialize()` 改成共用同一個 in-flight future，`_isInitializing` 旗標移除：

```dart
Future<void> initialize() {
  if (_isDisposed || _isInitialized) return Future<void>.value();
  return _initialization ??= _runInitialization();
}
```

失敗時在 `finally` 清掉 `_initialization`，保留原本「下一次呼叫可以重試」的語意
（舊碼靠 `_isInitializing` 在 `finally` 復位達成同一件事）。

契約寫進 `lib/services/audio/AGENTS.md` 新增的 § Initialization。

## 驗證

**新測試在舊碼上真的會失敗**，這是重點 —— 不會失敗的回歸測試守不住任何東西：

```
$ git checkout -- lib/services/audio/audio_provider.dart   # 退回修法前
$ flutter test ... --plain-name "a concurrent initialize waits for the in-flight one to wire up"
  timed out after 0:00:05.000000 waiting: the end reason emitted right after initialize must be heard
```

跟 CI 上的簽名逐字相同。加上修法後通過。CI 上只在負載下偶發的東西，在本機變成
5 秒內必現。

| 項目 | 結果 |
|---|---|
| `flutter analyze` | 乾淨 |
| `flutter test --coverage --exclude-tags live --concurrency=4`（照 CI 的旗標） | **1520 過**（原 1519 + 新增 1） |
| 新測試 vs 舊碼 | 以相同簽名失敗 |

## 沒做的

- **沒有動 `pumpUntil` 的 5 秒預算。** 調大只會把「必現的無聲丟失」變成「更久的
  必現無聲丟失」，那是把症狀換一邊 —— 正是 §6.15 對「把圈數調大」的同一個論點。
- **沒有重開 issue #43。** 它是 CLOSED，而它的「原因推測」段（怪 `pumpEventQueue`
  的固定圈數）只對了一半：那一輪修掉的是真實的第二個病（§6.15，194 處），但這條
  抖動不是它。要不要重開或補一則說明，等你決定。
