### PR TITLE
docs(review): record the v1.10.0 post-release verification

### DIFF
--- a/.claude/skills/verify-on-device/SKILL.md
+++ b/.claude/skills/verify-on-device/SKILL.md
@@ -274,6 +274,23 @@ raising the window first.
   sometimes — it silently no-ops when the foreground-lock rules say no, and the
   next capture is then of the wrong window. Prefer the flag; if you do use
   Win32, assert `GetForegroundWindow()` returns your HWND before you click.
+- **`PrintWindow` with `PW_RENDERFULLCONTENT` returns a frozen frame.** It looks
+  like a working capture — real colours, real layout — but it is the frame from
+  whenever the surface was last handed to the DWM, and it does not advance. Four
+  consecutive captures across two clicks and a keypress came back byte-identical
+  (same md5), which reads exactly like "the input never landed" and sent this
+  round chasing a non-existent click problem. Capture with
+  `Graphics.CopyFromScreen` over the window rect instead; raise the window first.
+- **A driving process that is not DPI-aware measures a different screen.**
+  Without `SetProcessDpiAwarenessContext(PER_MONITOR_AWARE_V2)` (pass `-4`),
+  `GetWindowRect` and `SetCursorPos` speak virtualized coordinates while
+  `CopyFromScreen` speaks physical pixels — a 1.5x gap at 150% scaling. The
+  symptom is that clicks computed off a screenshot land somewhere else entirely,
+  and that a crop at the reported rect shows a neighbouring window. Call it once
+  at the top of every script that measures, clicks or captures, and the three
+  agree. `orca computer list-windows` already reports physical coordinates, so
+  it disagreeing with your `GetWindowRect` by exactly the scale factor is the
+  tell.
 - **Pin the window with `--window-id`.** An app can own several top-level
   windows (FMP has the SMTC message window and two IME windows), and a modal
   file dialog is a window of its own.

--- a/docs/review/05-roadmap.md
+++ b/docs/review/05-roadmap.md
@@ -2847,3 +2847,26 @@ markdown，`**Full Changelog**` 會照字面出現）。1134 行會進那個 200
 - 憑證側實質單向：v9 透過 Jetpack Security / EncryptedSharedPreferences 讀，v10 已把
   資料遷出到自訂 cipher，裝回 v1.9.1 很可能要重登三個站台。**這是從 upstream
   changelog 推的，沒有實測降級。** patch 版號會讓人以為可以隨手裝回去。
+
+#### 五、發布後驗收：三條預測有兩條成立，第三條比預測更糟
+
+發布於 2026-09-08 17:02 UTC，`draft: false` 所以直接對外。
+
+| 項目 | 實測結果 |
+|---|---|
+| Release body | 與 `docs/release-notes/v1.10.0.md` **逐字相同**（各 4,118 字元），手寫檔確實完全擁有 body，沒有被 `## What's Changed` 前綴 |
+| compare 連結 | `compare/v1.9.1..v1.10.0`（兩點），沒有退化成三點 |
+| 產物 | 10 個 asset：4 個 ABI APK + universal + `fmp-latest-*` 三個別名 + windows zip + installer + checksums |
+| Windows 安裝版 | 實裝成功，登錄檔 `DisplayVersion = 1.10.0+1010000` —— CI 依 tag 算出的 `versionCode`（major×1000000 + minor×1000 + patch）如實落到安裝包上 |
+| Windows 可攜版 | zip 解壓後 `libisar.dll` 在、沒有殘留的舊名 `isar.dll`。這段改名落在未發布期間，而 zip/installer 打包不在 PR CI 的覆蓋範圍，所以只有這裡驗得到 |
+| App 內更新（雙位數 minor） | **實測通過**：v1.9.1 的 Android 建置 → 設定 → 檢查更新 → 抓到 v1.10.0、x86_64、32.3 MB。§二的 `_isNewerVersion` 判讀原本只是讀原始碼推的，現在有實際觀察 |
+
+第三段裡「1134 行會進那個 200px 的框」的預測沒有機會成立（手寫檔擋掉了），但**框本身
+的問題比預測更嚴重**：4,118 字元的手寫 markdown 在對話框裡是純文字，`## FMP v1.10.0`
+與 `### Playback` 照字面顯示，而 200px 只露得出前 8 行 —— 被蓋掉的內容裡包含這一版
+唯一需要事前知道的那句（降級回 v1.9.1 要重登三個來源），而且框沒有任何捲動提示。
+記為 issue #82。
+
+> 這一輪在 Windows 端的截圖與點擊上損失了不少時間，兩個坑（`PrintWindow` 回傳凍結
+> 畫格、驅動行程沒宣告 DPI awareness 導致座標差 1.5 倍）記在
+> `.claude/skills/verify-on-device/SKILL.md` §Driving the Windows build。


### PR DESCRIPTION
§6.17 只寫到發版前的盤點。這次補上發布後實際驗收的結果，以及一條原本只讀原始碼推斷、
現在有實測的判讀。

| 項目 | 實測 |
|---|---|
| Release body | 與 `docs/release-notes/v1.10.0.md` 逐字相同（各 4,118 字元） |
| compare 連結 | 兩點語法，沒退化成三點 |
| Windows 安裝版 | 登錄檔 `DisplayVersion = 1.10.0+1010000` |
| Windows 可攜版 | `libisar.dll` 在、沒有殘留的舊名 `isar.dll` |
| App 內更新 | v1.9.1 建置實測抓到 v1.10.0 —— 雙位數 minor 的比較確實成立 |

§6.17 第三段預測「1134 行會進那個 200px 的框」沒有機會成立（手寫檔擋掉了），但框本身
的問題比預測更嚴重，另開 #82。

Windows 端驅動的兩個工具坑（`PrintWindow` 回傳凍結畫格、驅動行程沒宣告 DPI awareness
導致座標差 1.5 倍）寫進 `verify-on-device` skill，roadmap 只留交叉引用。

`docs/**` 與 `.claude/**` 都不觸發 CI。