### PR TITLE
chore(android): 升級 Gradle / AGP / Kotlin 到 Flutter 3.47 建議版本

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -3,8 +3,9 @@ import java.io.FileInputStream
 
 plugins {
     id("com.android.application")
-    id("kotlin-android")
-    // The Flutter Gradle Plugin must be applied after the Android and Kotlin Gradle plugins.
+    // The Flutter Gradle Plugin must be applied after the Android Gradle plugin.
+    // 不要在這裡宣告 kotlin-android：AGP 9 下 Flutter Gradle Plugin 會自己幫 :app 套用 KGP，
+    // 應用端再宣告一次只會換來一段「future versions of Flutter will fail to build」警告。
     id("dev.flutter.flutter-gradle-plugin")
 }
 
@@ -22,10 +23,6 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
-    }
-
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_17.toString()
     }
 
     defaultConfig {
@@ -53,6 +50,12 @@ android {
                 signingConfigs.getByName("debug")
             }
         }
+    }
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
     }
 }
 

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -15,6 +15,16 @@ subprojects {
     val newSubprojectBuildDir: Directory = newBuildDir.dir(project.name)
     project.layout.buildDirectory.value(newSubprojectBuildDir)
 
+    // file_picker 11.0.3 只在 AGP < 9 時才套用 kotlin-android，AGP 9 以上它預期吃內建 Kotlin。
+    // 但 Flutter Gradle Plugin 是用正則掃 build.gradle 判斷子專案有沒有宣告 KGP，看不出那行被
+    // `if (!isAgp9OrAbove)` 包住，於是也不幫它補套用（FlutterPluginUtils.detectApplyingKotlinGradlePlugin）。
+    // 兩邊都以為對方會做，結果它的 Kotlin 原始碼沒人編譯，:app 會在 GeneratedPluginRegistrant
+    // 撞到 cannot find symbol FilePickerPlugin。這裡手動補上。
+    // 全域 android.builtInKotlin 為何不能開，見 gradle.properties。
+    if (project.name == "file_picker") {
+        project.pluginManager.apply("org.jetbrains.kotlin.android")
+    }
+
     // Fix namespace and compileSdk for old plugins
     afterEvaluate {
         if (project.hasProperty("android")) {

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,6 +1,12 @@
 org.gradle.jvmargs=-Xmx8G -XX:MaxMetaspaceSize=4G -XX:ReservedCodeCacheSize=512m -XX:+HeapDumpOnOutOfMemoryError
 android.useAndroidX=true
-# This builtInKotlin flag was added automatically by Flutter migrator
+# AGP 9 起 Kotlin 編譯內建於 AGP，但 package_info_plus 9.0.1 仍無條件套用 kotlin-android，
+# 開了內建 Kotlin 它會直接 apply 失敗。維持關閉（也是 Flutter 3.47 範本的預設），
+# 改由 Flutter Gradle Plugin 幫各子專案套用 KGP。等插件端跟上再翻成 true。
 android.builtInKotlin=false
 # This newDsl flag was added automatically by Flutter migrator
 android.newDsl=false
+# AGP 9 移除了 getDefaultProguardFile('proguard-android.txt')，因為它帶 -dontoptimize 會關掉 R8 優化。
+# flutter_inappwebview_android 1.1.3 仍在用舊檔名，上游未修（pichillilorenzo/flutter_inappwebview#2852），
+# 先用官方逃生門讓建置通過。這是暫時措施，AGP 之後版本會拿掉它；插件更新後刪掉這行。
+android.r8.proguardAndroidTxt.disallowed=false

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-all.zip

--- a/android/settings.gradle.kts
+++ b/android/settings.gradle.kts
@@ -19,8 +19,8 @@ pluginManagement {
 
 plugins {
     id("dev.flutter.flutter-plugin-loader") version "1.0.0"
-    id("com.android.application") version "8.11.1" apply false
-    id("org.jetbrains.kotlin.android") version "2.2.20" apply false
+    id("com.android.application") version "9.1.0" apply false
+    id("org.jetbrains.kotlin.android") version "2.4.0" apply false
 }
 
 include(":app")


### PR DESCRIPTION
Closes #86

## 版本前後

| 元件 | 之前 | 之後 |
|---|---|---|
| Gradle | 8.14 | 9.3.1 |
| Android Gradle Plugin | 8.11.1 | 9.1.0 |
| Kotlin Gradle Plugin | 2.2.20 | 2.4.0 |

JDK 維持 17（本機與 CI 都是），AGP 9.1 的最低要求也正是 17，`docs/building.md`
的環境需求不用動。

## 出處

這組不是挑最新，是挑 **Flutter 3.47.1 自己的專案範本值** —— 上游 CI 測的就是這組：

- `flutter_tools/lib/src/android/gradle_utils.dart`：
  `templateDefaultGradleVersion = '9.3.1'`、
  `templateAndroidGradlePluginVersion = '9.1.0'`、
  `templateKotlinGradlePluginVersion = '2.4.0'`。
  同一份檔案的 `GradleForAgp` 表寫著 AGP 9.1.x 需要 Gradle ≥ 9.3.1，
  `maxKnownAgpVersionWithFullKotlinSupport` 也停在 9.1.0。
- `flutter_tools/gradle/src/main/kotlin/DependencyVersionChecker.kt`：
  觸發 issue 裡那三段警告的門檻是 `warnGradleVersion = 9.1.0`、
  `warnAGPVersion = 9.0.1`、`warnKGPVersion = 2.3.20`，新版三個都越過了。
- [AGP 9.1.0 release notes](https://developer.android.com/build/releases/past-releases/agp-9-1-0-release-notes)：
  Gradle 最低與預設皆 9.3.1、JDK 17、SDK Build Tools 36.0.0。
- [Kotlin Gradle plugin 相容表](https://kotlinlang.org/docs/gradle-configure-project.html)：
  KGP 2.4.0 支援 Gradle 7.6.3–9.5.0、AGP 8.5.2–9.1.0。9.3.1 與 9.1.0 都在範圍內。
- [Gradle compatibility matrix](https://docs.gradle.org/current/userguide/compatibility.html)：
  Gradle 9.x 需要 JDK 17–26。

沒有選更新的 AGP 9.4：Flutter 3.47.1 的 `maxKnownAndSupportedAgpVersion` 只到 9.2，
超過就換一種「未知版本」警告，等於把問題換個形狀留著。

## AGP 9 是 major，順帶被逼出來的三件事

單純改版號是建不起來的。以下三處都在 `android/` 內，且都在原地寫了原因與拆除條件。

**1. `kotlinOptions` → `kotlin.compilerOptions`（`android/app/build.gradle.kts`）**

KGP 2.4 把 `kotlinOptions` / `jvmTarget` 標成 error 級 deprecation，Kotlin DSL
腳本直接編譯失敗。照
[Flutter 官方遷移指南](https://docs.flutter.dev/release/breaking-changes/migrate-to-built-in-kotlin/for-app-developers)
換成頂層 `kotlin { compilerOptions { jvmTarget = ... } }`，同時把 app 自己那行
`id("kotlin-android")` 拿掉 —— AGP 9 下 Flutter Gradle Plugin 會自己幫 `:app`
套用 KGP，應用端再宣告一次只會多一段「future versions of Flutter will fail to
build」警告。這與 Flutter 3.47 的 `app/android-kotlin.tmpl` 範本形狀一致。

**2. R8 逃生門（`android/gradle.properties`）**

AGP 9 移除了 `getDefaultProguardFile('proguard-android.txt')`（它帶
`-dontoptimize`，會擋掉 R8 優化）。`flutter_inappwebview_android` 1.1.3 還在用舊
檔名，configuration 階段就炸。上游 issue：
[pichillilorenzo/flutter_inappwebview#2852](https://github.com/pichillilorenzo/flutter_inappwebview/issues/2852)。
先開官方逃生門 `android.r8.proguardAndroidTxt.disallowed=false`，插件更新後刪掉。

**3. `file_picker` 的 KGP 三不管地帶（`android/build.gradle.kts`）**

兩個插件對 AGP 9 的期待正好相反：

- `file_picker` 11.0.3 偵測到 AGP ≥ 9 就**不**套用 KGP，預期吃 AGP 內建 Kotlin。
- `package_info_plus` 9.0.1 **無條件**套用 `kotlin-android`，開了內建 Kotlin 會
  直接 apply 失敗（`The 'org.jetbrains.kotlin.android' plugin is no longer
  required for Kotlin support since AGP 9.0`）。

所以 `android.builtInKotlin` 只能維持 `false`（也是 Flutter 3.47 範本的預設）。
但這時 `file_picker` 就沒人管了：Flutter Gradle Plugin 的
`FlutterPluginUtils.detectApplyingKotlinGradlePlugin` 是用**正則掃 build.gradle
原始碼**判斷子專案有沒有宣告 KGP，看不出 `file_picker` 那行被
`if (!isAgp9OrAbove)` 包住，於是誤判「它自己會套」而略過。兩邊都以為對方會做，
結果它的 Kotlin 原始碼沒人編譯，`:app` 在 `GeneratedPluginRegistrant.java`
撞到 `cannot find symbol: class FilePickerPlugin`。

修法是在 root build script 對那一個子專案補上 KGP。等 `package_info_plus` 升到
支援內建 Kotlin 的版本，這段和 `android.builtInKotlin=false` 可以一起拆掉，
換成整包走內建 Kotlin。

## 驗證

`flutter clean` 之後：

```
$ flutter build apk --release --target-platform android-arm64
Running Gradle task 'assembleRelease'...
WARNING: Your app uses the following plugins that apply Kotlin Gradle Plugin (KGP): file_picker, package_info_plus
Future versions of Flutter will fail to build if your app uses plugins that apply KGP.
...
Font asset "MaterialIcons-Regular.otf" was tree-shaken, reducing it from 1645184 to 30084 bytes (98.2% reduction).
Font asset "SimpleIcons.ttf" was tree-shaken, reducing it from 1458992 to 2160 bytes (99.9% reduction).
Running Gradle task 'assembleRelease'...                            90.0s
√ Built build\app\outputs\flutter-apk\app-release.apk (30.7MB)
```

- issue 裡那三段版本淘汰警告全部消失（整份 build log 掃 `deprecat` /
  `minimum supported` / `no longer support` 零命中）。
- 殘留的兩段警告都不是本 PR 造成的：KGP 那段是上面第 3 點講的插件端未來相容性提醒
  （`file_picker` 是正則誤判、`package_info_plus` 是真的），字體那段是
  `cupertino_icons` 的既有噪音。
- `flutter analyze`：`No issues found!`
- `flutter analyze --suggestions`：`[√] Java/Gradle/KGP/Android Gradle Plugin: compatible java/gradle/agp/kgp`

**未做：實機／模擬器安裝。** 模擬器目前被另一個任務佔用，所以 issue 驗收條目裡的
「模擬器實跑一次確認沒有新的執行期問題」留給後續。AGP/Kotlin 版本會影響 Isar 原生庫、
`just_audio`、`flutter_inappwebview` 的執行期行為，合併前建議補一次實機冒煙：
啟動 → 搜尋 → 播放 → 檔案選擇（`file_picker`，本 PR 動到它的編譯路徑）→
WebView 登入（`flutter_inappwebview`，本 PR 動到它的 R8 設定）。
