### PR TITLE
fix(ui): keep the collapsed rail reachable in short windows

### DIFF
--- a/lib/data/sources/AGENTS.md
+++ b/lib/data/sources/AGENTS.md
@@ -63,6 +63,13 @@ what reading them will not tell you.
 - Stream failures inspect per-song `code`/`message`/`fee`/`flag`. VIP/paid
   become `vipRequired`; copyright/region become `geoRestricted`; generic missing
   URLs become `unavailable`.
+- **"Not logged in" outranks "needs VIP", and `flag & 4` is not a VIP marker.**
+  Song `139774` measures `flag=6, code=200` and streams anonymously at 320kbps,
+  yet nearly every anonymous failure carries that bit — reading it as VIP told
+  users to pay when logging in was enough (#87). Login-required is `code == 301`
+  **and** `code == 404` with `fee == 0`: NetEase answers an anonymous request
+  for a free song exactly that way. Only `fee` (1 or 4) and VIP wording in the
+  message mean VIP.
 - Ranking fetches use the hot playlist plus song-detail metadata only — they
   must **not** resolve or refresh audio URLs.
 - Play auth defaults to on for Netease (`kDefaultUseAuthForPlayBySource`),

--- a/lib/data/sources/netease_source.dart
+++ b/lib/data/sources/netease_source.dart
@@ -932,7 +932,7 @@ class NeteaseSource
       );
     }
 
-    if (_isVipRequiredStreamError(fee: fee, flag: flag, message: message)) {
+    if (_isVipRequiredStreamError(fee: fee, message: message)) {
       return NeteaseApiException(
         numericCode: -10,
         message: message ?? 'VIP song, payment required',
@@ -959,6 +959,15 @@ class NeteaseSource
       );
     }
     if (itemCode == 404) {
+      // `fee == 0` 是網易明說「這不是付費歌曲」，卻連 URL 都不給 —— 匿名請求
+      // 就是長這樣，同一首登入後可播。以前這裡永遠碰不到：`flag & 4` 先在上面
+      // 把它判成需要 VIP，於是使用者被引導去付錢，而其實只要登入（#87）。
+      if (fee == 0) {
+        return NeteaseApiException(
+          numericCode: 301,
+          message: message ?? 'Login required',
+        );
+      }
       return NeteaseApiException(
         numericCode: 404,
         message: message ?? 'No stream URL available',
@@ -996,17 +1005,17 @@ class NeteaseSource
 
   /// 這首歌是不是真的需要 VIP。
   ///
-  /// `flag & 4` **不是** VIP 標記：實測歌曲 `139774` 是 `flag=6, code=200`，
-  /// 匿名就拿得到 320kbps 的 URL。它只在「本來就取不到串流」時當補充線索用，
-  /// 而且**必須排在未登入（`code == 301`）判斷之後** —— 沒登入的失敗常常同時
-  /// 帶著這個位元，先看它就會把「登入即可」說成「要付費」。
+  /// 判斷只看 `fee` 與訊息文字。**`flag & 4` 不是 VIP 標記**：實測歌曲 `139774`
+  /// 是 `flag=6, code=200`，匿名就拿得到 320kbps 的 URL。它以前排在這裡當「補充
+  /// 線索」，結果是每一個 `fee=0 / code=404 / url=null` 的未登入失敗都被說成要
+  /// 付費 —— 那個位元在沒登入的回應裡幾乎一定會出現，所以它不是補充線索，是雜
+  /// 訊（#87）。未登入現在由 `code == 301` 與 `code == 404 && fee == 0` 兩條分支
+  /// 接走。
   bool _isVipRequiredStreamError({
     required int? fee,
-    required int? flag,
     required String? message,
   }) {
     if (fee == 1 || fee == 4) return true;
-    if (flag != null && (flag & 4) != 0) return true;
     final normalized = message?.toLowerCase();
     if (normalized == null) return false;
     return normalized.contains('vip') ||

--- a/lib/i18n/en/audioSettings.i18n.json
+++ b/lib/i18n/en/audioSettings.i18n.json
@@ -35,5 +35,9 @@
     "bilibiliDescription": "Keep off unless playback needs member or private-content access.",
     "youtubeDescription": "Keep off unless playback needs account-only access.",
     "neteaseDescription": "Enabled by default for VIP and account-restricted tracks."
+  },
+  "secureStorageUnavailable": {
+    "title": "Credential store cannot be read",
+    "description": "This device cannot decrypt the stored credentials right now, so the saved AI API key was not loaded. Every other setting on this page is unaffected."
   }
 }

--- a/lib/i18n/en/settings.i18n.json
+++ b/lib/i18n/en/settings.i18n.json
@@ -107,6 +107,7 @@
     "aiApiKey": "API key",
     "aiApiKeyConfigured": "API key configured. Enter a new key to replace it, or leave empty to keep it.",
     "aiApiKeyEmpty": "No API key configured. Enter one to enable AI parsing.",
+    "aiApiKeyUnavailable": "The credential store cannot be read, so an existing key could not be loaded. It has not been deleted; entering a key here overwrites it.",
     "aiClearApiKey": "Clear API key",
     "aiModel": "Model",
     "aiModelHint": "Model name",

--- a/lib/i18n/zh-CN/audioSettings.i18n.json
+++ b/lib/i18n/zh-CN/audioSettings.i18n.json
@@ -35,5 +35,9 @@
     "bilibiliDescription": "除非需要大会员或私有内容播放，否则建议关闭。",
     "youtubeDescription": "除非需要账号限定内容播放，否则建议关闭。",
     "neteaseDescription": "默认开启，用于 VIP 或账号受限歌曲。"
+  },
+  "secureStorageUnavailable": {
+    "title": "读不到凭证存储",
+    "description": "这台设备目前解不开已保存的凭证，所以没有加载 AI API Key。本页其余设置不受影响。"
   }
 }

--- a/lib/i18n/zh-CN/settings.i18n.json
+++ b/lib/i18n/zh-CN/settings.i18n.json
@@ -107,6 +107,7 @@
     "aiApiKey": "API Key",
     "aiApiKeyConfigured": "已配置 API Key。输入新 Key 可替换，留空则保持不变。",
     "aiApiKeyEmpty": "未配置 API Key。输入后可启用 AI 解析。",
+    "aiApiKeyUnavailable": "读不到凭证存储，已保存的 API Key 这次没有加载。它没有被删除，在这里输入会覆盖它。",
     "aiClearApiKey": "清除 API Key",
     "aiModel": "模型",
     "aiModelHint": "模型名称",

--- a/lib/i18n/zh-TW/audioSettings.i18n.json
+++ b/lib/i18n/zh-TW/audioSettings.i18n.json
@@ -35,5 +35,9 @@
     "bilibiliDescription": "除非需要大會員或私人內容播放，否則建議關閉。",
     "youtubeDescription": "除非需要帳號限定內容播放，否則建議關閉。",
     "neteaseDescription": "預設開啟，用於 VIP 或帳號受限歌曲。"
+  },
+  "secureStorageUnavailable": {
+    "title": "讀不到憑證儲存",
+    "description": "這台裝置目前解不開已儲存的憑證，所以沒有載入 AI API Key。本頁其餘設定不受影響。"
   }
 }

--- a/lib/i18n/zh-TW/settings.i18n.json
+++ b/lib/i18n/zh-TW/settings.i18n.json
@@ -107,6 +107,7 @@
     "aiApiKey": "API Key",
     "aiApiKeyConfigured": "已設定 API Key。輸入新 Key 可替換，留空則保持不變。",
     "aiApiKeyEmpty": "未設定 API Key。輸入後可啟用 AI 解析。",
+    "aiApiKeyUnavailable": "讀不到憑證儲存，已存的 API Key 這次沒有載入。它沒有被刪除，在這裡輸入會覆蓋掉它。",
     "aiClearApiKey": "清除 API Key",
     "aiModel": "模型",
     "aiModelHint": "模型名稱",

--- a/lib/providers/audio/audio_settings_provider.dart
+++ b/lib/providers/audio/audio_settings_provider.dart
@@ -1,6 +1,8 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:fmp/core/constants/app_constants.dart';
+import 'package:fmp/core/logger.dart';
+import 'package:fmp/core/secure_key_value_store.dart';
 import 'package:fmp/data/models/settings.dart';
 import 'package:fmp/data/models/track.dart';
 import 'package:fmp/data/repositories/settings_repository.dart';
@@ -24,6 +26,13 @@ class AudioSettingsState {
   final int lyricsAiTimeoutSeconds;
   final bool lyricsAiApiKeyConfigured;
 
+  /// 這次載入時憑證儲存讀不出來。
+  ///
+  /// 與 [lyricsAiApiKeyConfigured] 為 false 不同：那是「沒設定過金鑰」，這是
+  /// 「金鑰可能還在，但這台機器現在解不開」。設定頁要能分辨，否則使用者會以為
+  /// 自己的金鑰被清掉了（#89）。
+  final bool secureStorageUnavailable;
+
   /// 每個音源是否在播放時帶上登入狀態，key 是 [SourceIds] 的音源 id。
   final Map<String, bool> useAuthForPlay;
   final bool isLoading;
@@ -41,6 +50,7 @@ class AudioSettingsState {
     this.lyricsAiModel = '',
     this.lyricsAiTimeoutSeconds = AppConstants.lyricsAiDefaultTimeoutSeconds,
     this.lyricsAiApiKeyConfigured = false,
+    this.secureStorageUnavailable = false,
     this.useAuthForPlay = const {},
     this.isLoading = true,
   });
@@ -71,6 +81,7 @@ class AudioSettingsState {
     String? lyricsAiModel,
     int? lyricsAiTimeoutSeconds,
     bool? lyricsAiApiKeyConfigured,
+    bool? secureStorageUnavailable,
     Map<String, bool>? useAuthForPlay,
     bool? isLoading,
   }) {
@@ -92,6 +103,8 @@ class AudioSettingsState {
           lyricsAiTimeoutSeconds ?? this.lyricsAiTimeoutSeconds,
       lyricsAiApiKeyConfigured:
           lyricsAiApiKeyConfigured ?? this.lyricsAiApiKeyConfigured,
+      secureStorageUnavailable:
+          secureStorageUnavailable ?? this.secureStorageUnavailable,
       useAuthForPlay: useAuthForPlay ?? this.useAuthForPlay,
       isLoading: isLoading ?? this.isLoading,
     );
@@ -99,7 +112,7 @@ class AudioSettingsState {
 }
 
 /// 音频设置管理器
-class AudioSettingsNotifier extends Notifier<AudioSettingsState> {
+class AudioSettingsNotifier extends Notifier<AudioSettingsState> with Logging {
   late SettingsRepository _settingsRepository;
   // `late`，不是 `late final`：`build()` 會重跑，而重跑時實例是同一個。
   late LyricsAiConfigService _lyricsAiConfigService;
@@ -118,7 +131,20 @@ class AudioSettingsNotifier extends Notifier<AudioSettingsState> {
   /// 加载设置
   Future<void> _loadSettings() async {
     _settings = await _settingsRepository.get();
-    final lyricsAiApiKey = await _lyricsAiConfigService.readApiKey();
+
+    // 憑證儲存讀不到不能讓例外逸出：`isLoading` 會永遠停在 true，音訊設定頁
+    // 就是一個永久的 spinner，歌詞 AI 設定也一樣拿不到值（#89）。三個 account
+    // service 早就各自降級成「沒有憑證」並記一條消毒過的 log，這裡是 #35 當時
+    // 漏掉的第四個 read，做同一件事：退回預設值，另外標記讓設定頁能說明原因。
+    var lyricsAiApiKey = '';
+    var secureStorageUnavailable = false;
+    try {
+      lyricsAiApiKey = await _lyricsAiConfigService.readApiKey();
+    } on SecureStorageUnavailable catch (error) {
+      logWarning('Lyrics AI key store unavailable: $error');
+      secureStorageUnavailable = true;
+    }
+
     state = AudioSettingsState(
       qualityLevel: _settings!.audioQualityLevel,
       formatPriority: _settings!.audioFormatPriorityList,
@@ -137,6 +163,7 @@ class AudioSettingsNotifier extends Notifier<AudioSettingsState> {
           ? AppConstants.lyricsAiDefaultTimeoutSeconds
           : _settings!.lyricsAiTimeoutSeconds,
       lyricsAiApiKeyConfigured: lyricsAiApiKey.isNotEmpty,
+      secureStorageUnavailable: secureStorageUnavailable,
       useAuthForPlay: {
         for (final sourceId in SourceIds.values)
           sourceId: _settings!.useAuthForPlay(sourceId),

--- a/lib/services/lyrics/lyrics_ai_config_service.dart
+++ b/lib/services/lyrics/lyrics_ai_config_service.dart
@@ -1,4 +1,5 @@
 import 'package:fmp/core/constants/app_constants.dart';
+import 'package:fmp/core/logger.dart';
 import 'package:fmp/core/secure_key_value_store.dart';
 import 'package:fmp/data/models/settings.dart';
 
@@ -24,7 +25,7 @@ class LyricsAiConfig {
       model.isNotEmpty;
 }
 
-class LyricsAiConfigService {
+class LyricsAiConfigService with Logging {
   LyricsAiConfigService({
     required Future<Settings> Function() loadSettings,
     SecureKeyValueStore? secureStorage,
@@ -38,7 +39,16 @@ class LyricsAiConfigService {
 
   Future<LyricsAiConfig> loadConfig() async {
     final settings = await _loadSettings();
-    final apiKey = await readApiKey();
+    // 「讀不到金鑰」與「沒設定金鑰」對這裡的結論是同一個：AI 解析不可用。
+    // 差別在於呼叫端要不要跟使用者解釋，那是 [readApiKey] 的例外負責的事 ——
+    // 這條路徑會被歌詞自動匹配踩到，往上丟只會讓整次匹配失敗。
+    String apiKey;
+    try {
+      apiKey = await readApiKey();
+    } on SecureStorageUnavailable catch (error) {
+      logWarning('Lyrics AI key store unavailable: $error');
+      apiKey = '';
+    }
     final timeoutSeconds = settings.lyricsAiTimeoutSeconds < 1
         ? AppConstants.lyricsAiDefaultTimeoutSeconds
         : settings.lyricsAiTimeoutSeconds;
@@ -52,6 +62,11 @@ class LyricsAiConfigService {
     );
   }
 
+  /// 讀出已存的 API key，沒存過就是空字串。
+  ///
+  /// 憑證儲存本身讀不出來時**丟 [SecureStorageUnavailable]**，不吞成空字串：
+  /// 「解不開既有密文」與「沒有金鑰」對使用者是兩件事，前者要告訴他金鑰還在、
+  /// 只是這台機器現在讀不到（#89）。每個呼叫端自己決定怎麼降級。
   Future<String> readApiKey() async {
     return (await _secureStorage.read(key: apiKeyStorageKey))?.trim() ?? '';
   }

--- a/lib/ui/AGENTS.md
+++ b/lib/ui/AGENTS.md
@@ -187,6 +187,14 @@ playing" compares source identity for the same reason — use a stronger key
   `responsive_scaffold.dart` picks chrome from `MediaQuery`; content measures
   its own `LayoutBuilder`. A content-level answer may rearrange content, never
   remove it.
+- **The collapsed navigation rail scrolls.** Six destinations with
+  `labelType: all` plus the expand button need about 540dp; a landscape phone
+  gives about 411dp and Windows' minimum window is 500dp. `CollapsedNavRail`
+  (`responsive_scaffold.dart`, shared by the tablet and desktop-collapsed
+  layouts) uses `NavigationRail.scrollable` with the expand button as a pinned
+  `leading`. Do not put it back into an outer `Column` + `Expanded`: that pushes
+  Settings — the one destination with no other entry point — off-screen
+  entirely, which is a functional failure, not a visual one (#84).
 - There is deliberately no `LayoutType`/`isMobile`/`isTablet`/`isDesktop`:
   naming window sizes after hardware violates Flutter's *Avoid checking for
   hardware types*, and a 600dp desktop window is not a tablet. For OS-level

--- a/lib/ui/AGENTS.md
+++ b/lib/ui/AGENTS.md
@@ -186,7 +186,11 @@ playing" compares source identity for the same reason — use a stronger key
   `columnsFor(containerWidth)` describes how many columns fit *this container*.
   `responsive_scaffold.dart` picks chrome from `MediaQuery`; content measures
   its own `LayoutBuilder`. A content-level answer may rearrange content, never
-  remove it.
+  remove anything the user can no longer reach — a ranking source, a list row, a
+  destination. Secondary decoration *on* a row may step aside: `RankingTrackTile`
+  drops the play-count group below its own threshold width, because the
+  alternative was an overflow stripe and a two-character artist name (#85). The
+  number comes back the moment there is room, and the row itself never moves.
 - **The collapsed navigation rail scrolls.** Six destinations with
   `labelType: all` plus the expand button need about 540dp; a landscape phone
   gives about 411dp and Windows' minimum window is 500dp. `CollapsedNavRail`

--- a/lib/ui/layouts/responsive_scaffold.dart
+++ b/lib/ui/layouts/responsive_scaffold.dart
@@ -182,30 +182,15 @@ class _MediumLayout extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final colorScheme = Theme.of(context).colorScheme;
-
     return Scaffold(
       body: Row(
         children: [
           SizedBox(
             width: AppLayout.railCollapsed,
-            child: Container(
-              color: colorScheme.surfaceContainerLow,
-              child: NavigationRail(
-                selectedIndex: selectedIndex,
-                onDestinationSelected: onDestinationSelected,
-                labelType: NavigationRailLabelType.all,
-                backgroundColor: Colors.transparent,
-                destinations: destinations
-                    .map(
-                      (d) => NavigationRailDestination(
-                        icon: Icon(d.icon),
-                        selectedIcon: Icon(d.selectedIcon),
-                        label: Text(d.label),
-                      ),
-                    )
-                    .toList(),
-              ),
+            // 平板版面沒有可展開的側欄，所以不給展開按鈕。
+            child: CollapsedNavRail(
+              selectedIndex: selectedIndex,
+              onDestinationSelected: onDestinationSelected,
             ),
           ),
           const VerticalDivider(width: 1, thickness: 1),
@@ -213,6 +198,72 @@ class _MediumLayout extends StatelessWidget {
         ],
       ),
       bottomNavigationBar: const _MiniPlayerSwitch(),
+    );
+  }
+}
+
+/// 收起態的導覽軌，平板版面與桌面收起態共用。
+///
+/// [onExpand] 是 null 時不畫展開按鈕 —— 平板版面沒有可展開的側欄。
+///
+/// **為什麼要捲動**：六個目的地在 `labelType: all` 下各約 76dp，加上頂端的選單
+/// 按鈕要約 540dp。橫向手機（約 411dp 高）與 Windows 的最小視窗高度都放不下，
+/// 而原本的 `Column` + `Expanded` 只會把最下面的項目擠出可視區 ——「設定」是六
+/// 個目的地裡唯一沒有其他入口的那個，於是版面瑕疵變成功能不可達（#84）。
+///
+/// 用 `NavigationRail` 自己的 `scrollable`，而不是外面包一層
+/// `SingleChildScrollView` + `IntrinsicHeight`：框架版本一樣只捲主群組，但選取
+/// 指示器動畫、語意樹與 `SafeArea` 都留在它們原本的位置。展開按鈕改當 `leading`
+/// （`leadingAtTop` 預設為 `true`）釘在頂端，捲動時不會跟著目的地離開畫面。
+class CollapsedNavRail extends StatelessWidget {
+  const CollapsedNavRail({
+    super.key,
+    required this.selectedIndex,
+    required this.onDestinationSelected,
+    this.onExpand,
+  });
+
+  final int selectedIndex;
+  final ValueChanged<int> onDestinationSelected;
+  final VoidCallback? onExpand;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final onExpand = this.onExpand;
+
+    return Container(
+      color: colorScheme.surfaceContainerLow,
+      child: NavigationRail(
+        selectedIndex: selectedIndex,
+        onDestinationSelected: onDestinationSelected,
+        labelType: NavigationRailLabelType.all,
+        backgroundColor: Colors.transparent,
+        scrollable: true,
+        leading: onExpand == null
+            ? null
+            : Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  IconButton(
+                    icon: const Icon(Icons.menu),
+                    onPressed: onExpand,
+                    tooltip: t.nav.expandNav,
+                  ),
+                  const SizedBox(height: 8),
+                  const Divider(indent: 12, endIndent: 12),
+                ],
+              ),
+        destinations: destinations
+            .map(
+              (d) => NavigationRailDestination(
+                icon: Icon(d.icon),
+                selectedIcon: Icon(d.selectedIcon),
+                label: Text(d.label),
+              ),
+            )
+            .toList(),
+      ),
     );
   }
 }
@@ -526,38 +577,10 @@ class _ExpandedLayoutState extends ConsumerState<_ExpandedLayout> {
   }
 
   Widget _buildCollapsedNav() {
-    final colorScheme = Theme.of(context).colorScheme;
-    return Container(
-      color: colorScheme.surfaceContainerLow,
-      child: Column(
-        children: [
-          const SizedBox(height: 8),
-          IconButton(
-            icon: const Icon(Icons.menu),
-            onPressed: () => _layoutNotifier.setRailExpanded(true),
-            tooltip: t.nav.expandNav,
-          ),
-          const SizedBox(height: 8),
-          const Divider(indent: 12, endIndent: 12),
-          Expanded(
-            child: NavigationRail(
-              selectedIndex: widget.selectedIndex,
-              onDestinationSelected: widget.onDestinationSelected,
-              labelType: NavigationRailLabelType.all,
-              backgroundColor: Colors.transparent,
-              destinations: destinations
-                  .map(
-                    (d) => NavigationRailDestination(
-                      icon: Icon(d.icon),
-                      selectedIcon: Icon(d.selectedIcon),
-                      label: Text(d.label),
-                    ),
-                  )
-                  .toList(),
-            ),
-          ),
-        ],
-      ),
+    return CollapsedNavRail(
+      selectedIndex: widget.selectedIndex,
+      onDestinationSelected: widget.onDestinationSelected,
+      onExpand: () => _layoutNotifier.setRailExpanded(true),
     );
   }
 }

--- a/lib/ui/pages/settings/audio_settings_page.dart
+++ b/lib/ui/pages/settings/audio_settings_page.dart
@@ -25,6 +25,10 @@ class AudioSettingsPage extends ConsumerWidget {
       appBar: AppBar(title: Text(t.audioSettings.title)),
       body: ListView(
         children: [
+          // 憑證儲存讀不到時本頁仍然載入完成（#89），但要說明為什麼 —— 沉默
+          // 降級會讓使用者以為金鑰被清掉了。
+          if (audioSettings.secureStorageUnavailable)
+            const _SecureStorageUnavailableNotice(),
           // 音质等级
           _QualityLevelSection(
             currentLevel: audioSettings.qualityLevel,
@@ -98,6 +102,28 @@ class AudioSettingsPage extends ConsumerWidget {
           const SizedBox(height: 16),
         ],
       ),
+    );
+  }
+}
+
+/// 憑證儲存這次讀不出來的提示。
+///
+/// 說「讀不到」而不是「沒有設定」：Android Keystore 在裝置還原後、Windows
+/// DPAPI 在使用者設定檔重建後都會解不開既有密文，金鑰其實還在（#89）。
+class _SecureStorageUnavailableNotice extends StatelessWidget {
+  const _SecureStorageUnavailableNotice();
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return ListTile(
+      leading: Icon(Icons.lock_outline, color: colorScheme.error),
+      title: Text(
+        t.audioSettings.secureStorageUnavailable.title,
+        style: TextStyle(color: colorScheme.error),
+      ),
+      subtitle: Text(t.audioSettings.secureStorageUnavailable.description),
+      isThreeLine: true,
     );
   }
 }

--- a/lib/ui/pages/settings/lyrics_source_settings_page.dart
+++ b/lib/ui/pages/settings/lyrics_source_settings_page.dart
@@ -553,9 +553,14 @@ class _AiTitleParsingSettingsDialogState
                 controller: widget.apiKeyController,
                 decoration: InputDecoration(
                   labelText: t.settings.lyricsSourceSettings.aiApiKey,
-                  helperText: widget.audioSettings.lyricsAiApiKeyConfigured
+                  // 三種狀態，不是兩種：憑證儲存讀不出來時金鑰其實還在，說
+                  // 「未設定」會讓使用者以為被清掉了（#89）。
+                  helperText: widget.audioSettings.secureStorageUnavailable
+                      ? t.settings.lyricsSourceSettings.aiApiKeyUnavailable
+                      : widget.audioSettings.lyricsAiApiKeyConfigured
                       ? t.settings.lyricsSourceSettings.aiApiKeyConfigured
                       : t.settings.lyricsSourceSettings.aiApiKeyEmpty,
+                  helperMaxLines: 3,
                   prefixIcon: const Icon(Icons.key_outlined),
                   border: const OutlineInputBorder(),
                 ),

--- a/lib/ui/widgets/track_tiles/ranking_track_tile.dart
+++ b/lib/ui/widgets/track_tiles/ranking_track_tile.dart
@@ -13,6 +13,17 @@ import 'package:fmp/ui/widgets/images/track_thumbnail.dart';
 import 'package:fmp/ui/widgets/indicators/vip_badge.dart';
 import 'package:fmp/ui/widgets/menus/context_menu_region.dart';
 
+/// 播放數群組還放得下的最小 tile 寬度。
+///
+/// 這一列的固定開銷是左右外距 32、名次欄 28、封面 48、選單按鈕 48 與兩個 16dp
+/// 間隔，共 188dp；播放數群組本身約 66dp（間隔 8 + 圖示 14 + 間隔 2 + 數字）。
+/// 320dp 以下同時放這兩者，藝人名就只剩個位數的像素 —— 播放數是次要資訊，
+/// 藝人名不是，所以窄的時候整組退場而不是兩個一起被壓扁（#85）。
+///
+/// 側欄展開加右側面板的橫向手機（約 268dp 內容欄）落在門檻以下，是這個值要
+/// 擋住的情境。
+const double _viewCountMinTileWidth = 320;
+
 /// 排行榜歌曲項目（首頁排行榜與探索頁共用）
 ///
 /// 顯示排名、封面、標題（含 VIP 標記）、歌手與播放數。
@@ -56,96 +67,136 @@ class RankingTrackTile extends ConsumerWidget {
             },
         onLongPress: onLongPress,
         borderRadius: AppRadius.borderRadiusMd,
-        child: Padding(
-          padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 16),
-          child: Row(
-            children: [
-              SizedBox(
-                width: 28,
-                child: Text(
-                  '$rank',
-                  textAlign: TextAlign.center,
-                  style: Theme.of(
-                    context,
-                  ).textTheme.bodyMedium?.copyWith(color: colorScheme.outline),
-                ),
+        child: LayoutBuilder(
+          builder: (context, constraints) {
+            // 這一列自己量自己的容器，不問視窗有多寬：同一個 tile 在首頁的單欄、
+            // 首頁的三欄與探索頁裡拿到的寬度都不一樣（見 lib/ui/AGENTS.md 的
+            // Layout Conventions）。
+            final isNarrow = constraints.maxWidth < _viewCountMinTileWidth;
+            final gap = isNarrow ? 8.0 : 16.0;
+
+            return Padding(
+              // 窄的時候外距也一起收：一個 236dp 的 tile 原本有 64dp（本列 32 +
+              // 首頁區塊 32）花在左右留白上，超過寬度的四分之一。內距縮小不影響
+              // 觸控目標 —— InkWell 在外面。
+              padding: EdgeInsets.symmetric(
+                vertical: 8,
+                horizontal: isNarrow ? 8 : 16,
               ),
-              const SizedBox(width: 16),
-              TrackThumbnail(
-                track: track,
-                size: AppSizes.thumbnailMedium,
-                borderRadius: 4,
-                isPlaying: isPlaying,
-              ),
-              const SizedBox(width: 16),
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  children: [
-                    Row(
+              child: Row(
+                children: [
+                  SizedBox(
+                    width: isNarrow ? 20 : 28,
+                    child: Text(
+                      '$rank',
+                      textAlign: TextAlign.center,
+                      style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                        color: colorScheme.outline,
+                      ),
+                    ),
+                  ),
+                  SizedBox(width: gap),
+                  TrackThumbnail(
+                    track: track,
+                    size: isNarrow
+                        ? AppSizes.thumbnailSmall
+                        : AppSizes.thumbnailMedium,
+                    borderRadius: 4,
+                    isPlaying: isPlaying,
+                  ),
+                  SizedBox(width: gap),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      mainAxisAlignment: MainAxisAlignment.center,
                       children: [
-                        Expanded(
-                          child: Text(
-                            track.title,
-                            maxLines: 1,
-                            overflow: TextOverflow.ellipsis,
-                            style: Theme.of(context).textTheme.bodyLarge
-                                ?.copyWith(
-                                  color: isPlaying ? colorScheme.primary : null,
-                                  fontWeight: isPlaying
-                                      ? FontWeight.w600
-                                      : null,
+                        Row(
+                          children: [
+                            Expanded(
+                              child: Text(
+                                track.title,
+                                maxLines: 1,
+                                overflow: TextOverflow.ellipsis,
+                                style: Theme.of(context).textTheme.bodyLarge
+                                    ?.copyWith(
+                                      color: isPlaying
+                                          ? colorScheme.primary
+                                          : null,
+                                      fontWeight: isPlaying
+                                          ? FontWeight.w600
+                                          : null,
+                                    ),
+                              ),
+                            ),
+                            if (track.isVip) ...[
+                              const SizedBox(width: 4),
+                              const VipBadge(),
+                            ],
+                          ],
+                        ),
+                        const SizedBox(height: 2),
+                        Row(
+                          children: [
+                            Flexible(
+                              child: Text(
+                                track.artist ?? t.general.unknownArtist,
+                                maxLines: 1,
+                                overflow: TextOverflow.ellipsis,
+                                style: Theme.of(context).textTheme.bodyMedium
+                                    ?.copyWith(
+                                      color: colorScheme.onSurfaceVariant,
+                                    ),
+                              ),
+                            ),
+                            if (track.viewCount != null && !isNarrow)
+                              // 整組包在 Flexible 裡：圖示與數字以前是不可縮的，
+                              // 可用寬度一低於「藝人名最小寬 + 播放數固有寬」整
+                              // 列就溢出（#85）。
+                              Flexible(
+                                child: Row(
+                                  mainAxisSize: MainAxisSize.min,
+                                  children: [
+                                    const SizedBox(width: 8),
+                                    Icon(
+                                      Icons.play_arrow,
+                                      size: 14,
+                                      color: colorScheme.outline,
+                                    ),
+                                    const SizedBox(width: 2),
+                                    Flexible(
+                                      child: Text(
+                                        formatCount(track.viewCount!),
+                                        maxLines: 1,
+                                        overflow: TextOverflow.ellipsis,
+                                        style: Theme.of(context)
+                                            .textTheme
+                                            .bodySmall
+                                            ?.copyWith(
+                                              color: colorScheme.outline,
+                                            ),
+                                      ),
+                                    ),
+                                  ],
                                 ),
-                          ),
+                              ),
+                          ],
                         ),
-                        if (track.isVip) ...[
-                          const SizedBox(width: 4),
-                          const VipBadge(),
-                        ],
                       ],
                     ),
-                    const SizedBox(height: 2),
-                    Row(
-                      children: [
-                        Flexible(
-                          child: Text(
-                            track.artist ?? t.general.unknownArtist,
-                            maxLines: 1,
-                            overflow: TextOverflow.ellipsis,
-                            style: Theme.of(context).textTheme.bodyMedium
-                                ?.copyWith(color: colorScheme.onSurfaceVariant),
-                          ),
-                        ),
-                        if (track.viewCount != null) ...[
-                          const SizedBox(width: 8),
-                          Icon(
-                            Icons.play_arrow,
-                            size: 14,
-                            color: colorScheme.outline,
-                          ),
-                          const SizedBox(width: 2),
-                          Text(
-                            formatCount(track.viewCount!),
-                            style: Theme.of(context).textTheme.bodySmall
-                                ?.copyWith(color: colorScheme.outline),
-                          ),
-                        ],
-                      ],
+                  ),
+                  if (isSelectionMode)
+                    _SelectionCheckbox(isSelected: isSelected, onTap: onTap)
+                  else
+                    PopupMenuButton<String>(
+                      icon: const Icon(Icons.more_vert),
+                      onSelected: (value) =>
+                          _handleMenuAction(context, ref, value),
+                      itemBuilder: (_) => _buildMenuItems(),
                     ),
-                  ],
-                ),
+                ],
               ),
-              if (isSelectionMode)
-                _SelectionCheckbox(isSelected: isSelected, onTap: onTap)
-              else
-                PopupMenuButton<String>(
-                  icon: const Icon(Icons.more_vert),
-                  onSelected: (value) => _handleMenuAction(context, ref, value),
-                  itemBuilder: (_) => _buildMenuItems(),
-                ),
-            ],
-          ),
+            );
+          },
         ),
       ),
     );

--- a/test/data/sources/netease_source_test.dart
+++ b/test/data/sources/netease_source_test.dart
@@ -295,32 +295,97 @@ void main() {
       );
     });
 
-    test(
-      'a VIP song that is not a login failure is still reported as VIP',
-      () async {
-        final source = NeteaseSource(
-          dio: _dioReturning({
-            'code': 200,
-            'data': [
-              {'id': 1831476071, 'url': null, 'code': 404, 'fee': 0, 'flag': 4},
-            ],
-          }),
-        );
+    test('code 404 on a free song means login required, not VIP', () async {
+      // 網易對匿名請求就是這樣回的：`fee = 0` 明說不是付費歌曲，卻連 URL 都不
+      // 給。這個組合以前撞在 `flag & 4` 上被說成需要 VIP，使用者被引導去付錢，
+      // 而其實只要登入（#87）。正確的字串 `sourceErrorLoginRequired` 一直都在
+      // repo 裡，只是掛在 `code == 301` 上，永遠選不到。
+      final source = NeteaseSource(
+        dio: _dioReturning({
+          'code': 200,
+          'data': [
+            {'id': 1831476071, 'url': null, 'code': 404, 'fee': 0, 'flag': 4},
+          ],
+        }),
+      );
 
-        await expectLater(
-          source.getAudioStream(
-            const AudioStreamRequest(sourceId: '1831476071'),
+      await expectLater(
+        source.getAudioStream(const AudioStreamRequest(sourceId: '1831476071')),
+        throwsA(
+          isA<NeteaseApiException>()
+              .having((e) => e.kind, 'kind', SourceErrorKind.loginRequired)
+              .having((e) => e.code, 'code', 'login_required')
+              .having((e) => e.isVipRequired, 'isVipRequired', isFalse),
+        ),
+      );
+    });
+
+    test('the flag bit alone never means VIP', () async {
+      // 實測歌曲 139774 是 `flag=6, code=200`，匿名就拿得到 320kbps 的 URL ——
+      // 這個位元不是 VIP 標記。沒有 fee、也沒有付費字樣時就不准說要付費。
+      final source = NeteaseSource(
+        dio: _dioReturning({
+          'code': 200,
+          'data': [
+            {'id': 139774, 'url': null, 'code': -110, 'fee': 0, 'flag': 6},
+          ],
+        }),
+      );
+
+      await expectLater(
+        source.getAudioStream(const AudioStreamRequest(sourceId: '139774')),
+        throwsA(
+          isA<NeteaseApiException>()
+              .having((e) => e.isVipRequired, 'isVipRequired', isFalse)
+              .having((e) => e.isGeoRestricted, 'isGeoRestricted', isTrue),
+        ),
+      );
+    });
+
+    test('code 404 on a paid song is still reported as VIP', () async {
+      final source = NeteaseSource(
+        dio: _dioReturning({
+          'code': 200,
+          'data': [
+            {'id': 1831476071, 'url': null, 'code': 404, 'fee': 4, 'flag': 4},
+          ],
+        }),
+      );
+
+      await expectLater(
+        source.getAudioStream(const AudioStreamRequest(sourceId: '1831476071')),
+        throwsA(
+          isA<NeteaseApiException>().having(
+            (e) => e.isVipRequired,
+            'isVipRequired',
+            isTrue,
           ),
-          throwsA(
-            isA<NeteaseApiException>().having(
-              (e) => e.isVipRequired,
-              'isVipRequired',
-              isTrue,
-            ),
+        ),
+      );
+    });
+
+    test('code 404 with no fee at all stays unavailable', () async {
+      // `fee` 不在回應裡就沒有「明確不是付費歌曲」這個證據，不能猜成未登入。
+      final source = NeteaseSource(
+        dio: _dioReturning({
+          'code': 200,
+          'data': [
+            {'id': 555, 'url': null, 'code': 404},
+          ],
+        }),
+      );
+
+      await expectLater(
+        source.getAudioStream(const AudioStreamRequest(sourceId: '555')),
+        throwsA(
+          isA<NeteaseApiException>().having(
+            (e) => e.kind,
+            'kind',
+            SourceErrorKind.unavailable,
           ),
-        );
-      },
-    );
+        ),
+      );
+    });
 
     test('login required wins over a VIP-looking message', () async {
       final source = NeteaseSource(

--- a/test/providers/audio_settings_secure_storage_test.dart
+++ b/test/providers/audio_settings_secure_storage_test.dart
@@ -1,0 +1,99 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fmp/core/secure_key_value_store.dart';
+import 'package:fmp/data/models/settings.dart';
+import 'package:fmp/services/lyrics/lyrics_ai_config_service.dart';
+
+import '../support/audio_settings_notifier.dart';
+import '../support/fakes/fake_secure_key_value_store.dart';
+import '../support/fakes/fake_settings_repository.dart';
+import '../support/fakes/secure_storage_channel.dart';
+
+/// 憑證儲存讀不到時的降級（#89）。
+///
+/// `SecureKeyValueStore` 把平台失敗翻成 `SecureStorageUnavailable`，三個 account
+/// service 都各自接住降級成登出。issue #35 只列了那三個 `read()`，漏掉音訊設定
+/// 這一路 —— 例外一逸出，`isLoading` 就永遠停在 true，音訊設定頁是一個永久的
+/// spinner。
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('AudioSettingsNotifier with an unreadable credential store', () {
+    test('finishes loading instead of spinning forever', () async {
+      mockSecureStorageChannel(failing: true);
+      final settings = Settings()
+        ..lyricsAiEndpoint = 'https://api.example.com/v1'
+        ..lyricsAiModel = 'gpt-test';
+      final notifier = audioSettingsNotifierFor(
+        FakeSettingsRepository(settings),
+      );
+
+      await Future<void>.delayed(Duration.zero);
+
+      expect(notifier.state.isLoading, isFalse);
+      // Isar 裡的設定照樣載入 —— 讀不到的只有金鑰。
+      expect(notifier.state.lyricsAiEndpoint, 'https://api.example.com/v1');
+      expect(notifier.state.lyricsAiModel, 'gpt-test');
+    });
+
+    test('flags the failure instead of claiming there is no key', () async {
+      mockSecureStorageChannel(failing: true);
+      final notifier = audioSettingsNotifierFor(
+        FakeSettingsRepository(Settings()),
+      );
+
+      await Future<void>.delayed(Duration.zero);
+
+      expect(notifier.state.secureStorageUnavailable, isTrue);
+      // 金鑰可能還在，只是這台機器解不開，所以「已設定」也不能說是 true。
+      expect(notifier.state.lyricsAiApiKeyConfigured, isFalse);
+    });
+
+    test('a working store leaves the flag clear', () async {
+      mockSecureStorageChannel(values: const {'lyrics_ai_api_key': 'secret'});
+      final notifier = audioSettingsNotifierFor(
+        FakeSettingsRepository(Settings()),
+      );
+
+      await Future<void>.delayed(Duration.zero);
+
+      expect(notifier.state.isLoading, isFalse);
+      expect(notifier.state.secureStorageUnavailable, isFalse);
+      expect(notifier.state.lyricsAiApiKeyConfigured, isTrue);
+    });
+  });
+
+  group('LyricsAiConfigService with an unreadable credential store', () {
+    test('reports AI as unavailable instead of throwing', () async {
+      final service = LyricsAiConfigService(
+        loadSettings: () async => Settings()
+          ..lyricsAiTitleParsingMode = LyricsAiTitleParsingMode.alwaysAi
+          ..lyricsAiEndpoint = 'https://api.example.com/v1'
+          ..lyricsAiModel = 'gpt-test',
+        secureStorage: UnavailableSecureKeyValueStore(),
+      );
+
+      // 歌詞自動匹配會踩到這條路徑，往上丟只會讓整次匹配失敗。
+      final config = await service.loadConfig();
+
+      expect(config.apiKey, isEmpty);
+      expect(config.isAvailable, isFalse);
+      expect(config.endpoint, 'https://api.example.com/v1');
+    });
+
+    test('readApiKey still tells the caller the store is unreadable', () async {
+      final store = UnavailableSecureKeyValueStore();
+      final service = LyricsAiConfigService(
+        loadSettings: () async => Settings(),
+        secureStorage: store,
+      );
+
+      // 這裡刻意不吞：呼叫端要能分辨「沒有金鑰」與「讀不到金鑰」，設定頁的
+      // 提示就是靠這個分辨的。
+      await expectLater(
+        service.readApiKey(),
+        throwsA(isA<SecureStorageUnavailable>()),
+      );
+      expect(store.readCount, 1);
+    });
+  });
+}

--- a/test/support/fakes/secure_storage_channel.dart
+++ b/test/support/fakes/secure_storage_channel.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+const _channel = MethodChannel('plugins.it_nomads.com/flutter_secure_storage');
+
+/// 讓 `flutter_secure_storage` 的平台通道照 [values] 回答，或整條失敗。
+///
+/// 用通道而不是 `FlutterSecureStorage.setMockInitialValues`：後者換掉的是
+/// `FlutterSecureStoragePlatform.instance` 這個全域欄位而且不會還原，同一個檔案
+/// 裡先跑過它的測試會讓後面每一條的通道 mock 都被繞過 —— 症狀是「注入的失敗沒
+/// 有發生」，看起來像產品碼把例外吞了。
+///
+/// 走真的通道還有一個好處：`FlutterSecureKeyValueStore` 把 `PlatformException`
+/// 翻成 `SecureStorageUnavailable` 的那一段也一起驗到。
+void mockSecureStorageChannel({
+  Map<String, String> values = const {},
+  bool failing = false,
+}) {
+  final store = Map<String, String>.from(values);
+  TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+      .setMockMethodCallHandler(_channel, (call) async {
+        if (failing) {
+          throw PlatformException(code: 'decrypt_failed');
+        }
+        final arguments = (call.arguments as Map?) ?? const {};
+        final key = arguments['key'] as String?;
+        switch (call.method) {
+          case 'read':
+            return store[key];
+          case 'readAll':
+            return store;
+          case 'containsKey':
+            return store.containsKey(key);
+          case 'write':
+            store[key!] = arguments['value'] as String;
+            return null;
+          case 'delete':
+            store.remove(key);
+            return null;
+          case 'deleteAll':
+            store.clear();
+            return null;
+          default:
+            return null;
+        }
+      });
+  addTearDown(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(_channel, null);
+  });
+}

--- a/test/ui/layouts/collapsed_nav_rail_test.dart
+++ b/test/ui/layouts/collapsed_nav_rail_test.dart
@@ -1,0 +1,113 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fmp/core/constants/app_layout.dart';
+import 'package:fmp/i18n/strings.g.dart';
+import 'package:fmp/ui/layouts/responsive_scaffold.dart';
+
+/// 收起態導覽軌在矮視窗的行為（#84）。
+///
+/// 橫向手機約 411dp 高，扣掉迷你播放器之後導覽軌拿到的更少；六個目的地加展開
+/// 按鈕要約 540dp。以前這裡是 `Column` + `Expanded`，放不下就把最後一個目的地
+/// 擠出可視區 —— 而最後一個是「設定」，六個裡唯一沒有其他入口的那個。
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() => LocaleSettings.setLocale(AppLocale.en));
+
+  Future<int?> pumpRail(
+    WidgetTester tester, {
+    required double height,
+    bool withExpandButton = true,
+  }) async {
+    int? selected;
+    await tester.binding.setSurfaceSize(Size(AppLayout.railCollapsed, height));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+    await tester.pumpWidget(
+      TranslationProvider(
+        child: MaterialApp(
+          home: Scaffold(
+            body: Row(
+              children: [
+                SizedBox(
+                  width: AppLayout.railCollapsed,
+                  child: CollapsedNavRail(
+                    selectedIndex: 0,
+                    onDestinationSelected: (index) => selected = index,
+                    onExpand: withExpandButton ? () {} : null,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+    return selected;
+  }
+
+  testWidgets('411dp tall fits without overflowing', (tester) async {
+    await pumpRail(tester, height: 411);
+
+    // `RenderFlex overflowed` 會被 `FlutterError.onError` 收成一個 exception，
+    // 測試框架在這裡就會看到它。這條在改成 scrollable 之前是紅的。
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('settings can be reached by scrolling the rail', (tester) async {
+    await pumpRail(tester, height: 411);
+
+    final settings = find.text(t.nav.settings);
+    expect(
+      settings,
+      findsOneWidget,
+      reason: 'the destination is built, it is only off-screen',
+    );
+
+    // 軌只有 72dp 寬，捲動手勢必須落在軌自己身上而不是被旁邊的內容區搶走。
+    await tester.drag(find.byType(NavigationRail), const Offset(0, -200));
+    await tester.pumpAndSettle();
+
+    await tester.tap(settings);
+    await tester.pump();
+    expect(
+      tester.takeException(),
+      isNull,
+      reason: 'tapping settings must not hit an off-screen widget',
+    );
+  });
+
+  testWidgets('the expand button stays pinned while destinations scroll', (
+    tester,
+  ) async {
+    await pumpRail(tester, height: 411);
+
+    final menuButton = find.byIcon(Icons.menu);
+    final before = tester.getTopLeft(menuButton);
+
+    await tester.drag(find.byType(NavigationRail), const Offset(0, -200));
+    await tester.pumpAndSettle();
+
+    expect(tester.getTopLeft(menuButton), before);
+  });
+
+  testWidgets('the tablet rail has no expand button', (tester) async {
+    await pumpRail(tester, height: 411, withExpandButton: false);
+
+    expect(find.byIcon(Icons.menu), findsNothing);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('a tall window still shows every destination on screen', (
+    tester,
+  ) async {
+    await pumpRail(tester, height: 900);
+
+    final railBottom = tester.getRect(find.byType(NavigationRail)).bottom;
+    expect(
+      tester.getRect(find.text(t.nav.settings)).bottom,
+      lessThan(railBottom),
+    );
+    expect(tester.takeException(), isNull);
+  });
+}

--- a/test/ui/pages/settings/audio_settings_secure_storage_notice_test.dart
+++ b/test/ui/pages/settings/audio_settings_secure_storage_notice_test.dart
@@ -1,0 +1,97 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fmp/data/database/repository_providers.dart';
+import 'package:fmp/data/models/settings.dart';
+import 'package:fmp/i18n/strings.g.dart';
+import 'package:fmp/ui/pages/settings/audio_settings_page.dart';
+import 'package:fmp/ui/pages/settings/lyrics_source_settings_page.dart';
+
+import '../../../support/fakes/fake_settings_repository.dart';
+import '../../../support/fakes/secure_storage_channel.dart';
+
+/// 憑證儲存讀不到時這兩頁該長什麼樣（#89）。
+///
+/// 以前是一個永遠不會停的 `CircularProgressIndicator`：`isLoading` 預設 true，
+/// 而 `readApiKey()` 的例外沒有人接，載入函式就在那一行結束了。
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  Future<void> pump(WidgetTester tester, Widget page) async {
+    LocaleSettings.setLocale(AppLocale.en);
+    await tester.pumpWidget(
+      TranslationProvider(
+        child: ProviderScope(
+          overrides: [
+            settingsRepositoryProvider.overrideWith(
+              (ref) => FakeSettingsRepository(Settings()),
+            ),
+          ],
+          child: MaterialApp(home: page),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('audio settings loads and explains the failure', (tester) async {
+    mockSecureStorageChannel(failing: true);
+
+    await pump(tester, const AudioSettingsPage());
+
+    expect(find.byType(CircularProgressIndicator), findsNothing);
+    expect(
+      find.text(t.audioSettings.secureStorageUnavailable.title),
+      findsOneWidget,
+    );
+    // 頁面其餘內容照樣在 —— 這一頁的設定全都在 Isar 裡，跟憑證儲存無關。
+    expect(find.text(t.audioSettings.qualityLevel.title), findsOneWidget);
+  });
+
+  testWidgets('audio settings shows no notice when the store works', (
+    tester,
+  ) async {
+    mockSecureStorageChannel();
+
+    await pump(tester, const AudioSettingsPage());
+
+    expect(find.byType(CircularProgressIndicator), findsNothing);
+    expect(
+      find.text(t.audioSettings.secureStorageUnavailable.title),
+      findsNothing,
+    );
+  });
+
+  testWidgets('the AI key field says unreadable, not unconfigured', (
+    tester,
+  ) async {
+    mockSecureStorageChannel(failing: true);
+
+    await pump(tester, const LyricsSourceSettingsPage());
+    await tester.tap(find.byIcon(Icons.smart_toy_outlined));
+    await tester.pumpAndSettle();
+
+    // 「未設定」會讓使用者以為金鑰被清掉了，它其實還在。
+    expect(
+      find.text(t.settings.lyricsSourceSettings.aiApiKeyUnavailable),
+      findsOneWidget,
+    );
+    expect(
+      find.text(t.settings.lyricsSourceSettings.aiApiKeyEmpty),
+      findsNothing,
+    );
+  });
+
+  testWidgets('a stored key still reads as configured', (tester) async {
+    mockSecureStorageChannel(values: const {'lyrics_ai_api_key': 'secret'});
+
+    await pump(tester, const LyricsSourceSettingsPage());
+    await tester.tap(find.byIcon(Icons.smart_toy_outlined));
+    await tester.pumpAndSettle();
+
+    expect(
+      find.text(t.settings.lyricsSourceSettings.aiApiKeyConfigured),
+      findsOneWidget,
+    );
+  });
+}

--- a/test/ui/widgets/track_tiles/ranking_track_tile_test.dart
+++ b/test/ui/widgets/track_tiles/ranking_track_tile_test.dart
@@ -1,0 +1,98 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fmp/data/models/track.dart';
+import 'package:fmp/i18n/strings.g.dart';
+import 'package:fmp/providers/audio/audio_player_selectors.dart';
+import 'package:fmp/ui/widgets/track_tiles/ranking_track_tile.dart';
+
+/// 排行榜列在窄容器裡的行為（#85）。
+///
+/// 側欄展開加右側面板的橫向手機，中間內容欄只剩約 268dp。那一列的第二行以前是
+/// 「可縮的藝人名 + 完全不可縮的播放數群組」，可用寬度一低於群組的固有寬就整列
+/// 溢出 —— 版面層沒有做錯什麼，是這個元件自己不會縮。
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() => LocaleSettings.setLocale(AppLocale.en));
+
+  Future<void> pumpTile(WidgetTester tester, double width) async {
+    await tester.binding.setSurfaceSize(Size(width, 200));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+    await tester.pumpWidget(
+      TranslationProvider(
+        child: ProviderScope(
+          overrides: [currentTrackProvider.overrideWithValue(null)],
+          child: MaterialApp(
+            home: Scaffold(
+              body: SizedBox(
+                width: width,
+                child: RankingTrackTile(track: _track(), rank: 1),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+  }
+
+  testWidgets('the narrowest real column does not overflow', (tester) async {
+    // 236dp 是算出來的最窄情境：914dp 寬的橫向手機扣掉展開側欄 256、分隔線 1、
+    // 面板 366 + pane spacer 24，內容欄剩約 268dp，再扣首頁排行榜區塊的 32dp
+    // 左右外距。
+    await pumpTile(tester, 236);
+
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('the artist survives while the play count steps aside', (
+    tester,
+  ) async {
+    await pumpTile(tester, 236);
+
+    expect(find.text('Tester'), findsOneWidget);
+    // 播放數是次要資訊，藝人名不是 —— 窄的時候先讓播放數走。
+    expect(find.byIcon(Icons.play_arrow), findsNothing);
+  });
+
+  testWidgets('the title gets twice the width it used to', (tester) async {
+    await pumpTile(tester, 236);
+
+    final titleWidth = tester.getSize(find.text(_longTitle)).width;
+    // 修之前是 48dp —— 一列 236dp 裡有 148dp 是固定開銷（外距 32、名次 28、封面
+    // 48、選單按鈕 48）。收窄外距、間隔、名次欄與封面之後是 96dp，六個全形字。
+    // 再往上只剩「拿掉封面」或「拿掉選單按鈕」兩條路，兩條都會少掉功能。
+    expect(titleWidth, greaterThanOrEqualTo(96));
+  });
+
+  testWidgets('a wide column still shows the play count', (tester) async {
+    await pumpTile(tester, 600);
+
+    expect(find.byIcon(Icons.play_arrow), findsOneWidget);
+    expect(find.text('Tester'), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('the play count cannot overflow just above the threshold', (
+    tester,
+  ) async {
+    // 門檻上緣：播放數還在，但空間只剛好夠。整組現在包在 Flexible 裡，所以
+    // 它會 ellipsis 而不是把整列撐破。
+    await pumpTile(tester, 321);
+
+    expect(find.byIcon(Icons.play_arrow), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+}
+
+const _longTitle = '晴天雨天陰天多雲時晴的那一個下午';
+
+Track _track() {
+  return Track()
+    ..sourceId = 'ne-1'
+    ..sourceType = SourceIds.netease
+    ..title = _longTitle
+    ..artist = 'Tester'
+    ..viewCount = 12345678;
+}


### PR DESCRIPTION
Four issues from the post-audit plan's M1 §1.B, one commit each.

## #84 — the collapsed rail overflowed and took Settings with it

Six destinations at `labelType: all` plus the expand button need about **540dp**
of rail. A landscape phone gives about 411dp, so the outer `Column` +
`Expanded` overflowed and pushed the last destination off-screen — and the last
destination is **Settings**, the only one with no other entry point. That turned
a visual defect into an unreachable feature.

`NavigationRail` already has `scrollable`, and `leadingAtTop` defaults to `true`,
so the expand button becomes a pinned `leading` and only the destinations scroll.
Hand-rolling `SingleChildScrollView` + `IntrinsicHeight` (the shape the issue
suggested) reaches the same layout but moves the selection-indicator animation,
the semantics tree and `SafeArea` out of their framework positions, so the
built-in flag wins.

The tablet layout and the desktop-collapsed layout were building the same rail
twice; they now share `CollapsedNavRail`, which is also what the regression test
pumps.

**Verification**

- `test/ui/layouts/collapsed_nav_rail_test.dart` — 5 tests. Confirmed it catches
  the regression: flipping `scrollable` back to `false` reports
  `A RenderFlex overflowed by 141 pixels on the bottom` at 411dp (61px for the
  tablet rail, which has no expand button).
- Android emulator `Medium_Phone`, landscape `2400x1080px = 914x411dp`:
  - `02-collapsed-rail.png` — collapsed rail, no overflow stripe. Home, Search,
    Queue, Library, Radio visible; Settings below the fold.
  - `03-rail-scrolled.png` — a vertical drag started **inside the 72dp rail**
    scrolls it (the adjacent content column does not steal the gesture), Settings
    comes fully into view, and the menu button has not moved.
  - `04-settings-open.png` — tapping Settings opens the page and the rail
    highlight follows.

## #85 — the ranking row could not shrink

The second line paired a `Flexible` artist name with a play-count group — gap,
icon, gap, number — that had **no flexible wrapper at all**. Once the available
width fell below that group's intrinsic width the whole row overflowed. The
audit was right that this is an element defect, not a layout one: the same tile
overflows in any narrow container, and closing the panel for the user would have
been the wrong fix.

The group is now wrapped so it can ellipsize, and below a threshold it steps
aside entirely — play count is secondary, the artist name is not. At that width
the row also tightens its padding, gaps, rank column and cover.

**Acceptance not fully met, stated plainly.** The title goes from **48dp to
96dp** — six full-width characters, not the eight the task asked for. The
arithmetic: at the worst real width the tile is ~236dp (914dp window − 256dp
expanded rail − 1dp divider − 366dp panel − 24dp pane spacer = ~268dp content
column, − 32dp of section padding), and 140dp of that is fixed chrome: 16dp
padding, 20dp rank, 40dp cover, 48dp overflow menu, two 8dp gaps. Reaching eight
characters needs another ~32dp, and the only places left to take it from are the
cover or the overflow menu — the menu is the sole touch path to track actions
(`ContextMenuRegion` is right-click only), and the cover carries the now-playing
indicator. I stopped rather than remove either without being asked.

**Verification**

- `test/ui/widgets/track_tiles/ranking_track_tile_test.dart` — 5 tests, including
  the measured title width and "no overflow just above the threshold".
- Android emulator, landscape, sidebar expanded **and** Now Playing panel open
  (the exact repro):
  - `06-rail-expanded-with-panel.png`, `07-netease-rows-narrow.png` — no overflow
    stripes anywhere. Artist names survive: `马也_Cra…`, `郑润泽`, `孙燕姿`,
    `队长`. The play count has stepped aside.
  - `14-portrait-home.png` — portrait (411dp wide) is above the threshold and is
    unchanged: 48dp covers, 16dp gaps, play counts (`148.0M`, `32.0M`) all still
    there.

## #87 — an anonymous NetEase 404 was reported as "needs VIP"

`flag & 4` sat at the top of the VIP check while the comment two screens below it
already said the bit is not a VIP marker, with a measured counter-example: song
`139774` is `flag=6, code=200` and streams anonymously at 320kbps. Nearly every
anonymous failure carries that bit, so a free song answering
`fee=0 / code=404 / url=null` was told to buy a membership — and the `code == 404`
branch underneath was unreachable.

The bit is gone; `fee` and the message wording decide VIP. `code == 404` with
`fee == 0` now maps to login-required, which is what NetEase answers an anonymous
request for a free song. The string `sourceErrorLoginRequired` was already in the
repo, reachable only through `code == 301`. A 404 with **no** `fee` field stays
`unavailable` — there is no evidence either way.

**Verification** — `flutter test test/data/sources/netease_source_test.dart`, 15
tests. The pre-existing test that asserted `code:404, fee:0, flag:4` *is* VIP was
pinning the bug and is replaced; three cases added (free 404 → login required,
paid 404 → still VIP, 404 with no fee → unavailable) plus one that the flag bit
alone never means VIP.

## #89 — the fourth `read()` #35 missed

`SecureKeyValueStore` turns platform failures into `SecureStorageUnavailable` and
all three account services degrade to logged-out. #35 listed three `read()` calls
and missed `AudioSettingsNotifier._loadSettings`, which reads the lyrics AI key:
the exception escaped, `isLoading` stayed `true`, and the audio settings page was
a spinner that never stopped.

The read now degrades to an empty key **and raises a flag**, because "cannot
decrypt the stored key" is not "there is no key" — saying the latter reads as if
the key had been deleted. The audio settings page explains the failure and the AI
key field gets a third helper state. `LyricsAiConfigService.loadConfig()` degrades
too: lyrics auto-matching sits on that path and an escaping exception failed the
whole match. `readApiKey()` itself still throws, so each caller keeps its own
choice.

**Verification**

- `test/providers/audio_settings_secure_storage_test.dart` and
  `test/ui/pages/settings/audio_settings_secure_storage_notice_test.dart` — 9
  tests. They fail the **real** platform channel rather than injecting a fake, so
  `FlutterSecureKeyValueStore`'s `PlatformException` → `SecureStorageUnavailable`
  translation is covered too. (`FlutterSecureStorage.setMockInitialValues`
  replaces `FlutterSecureStoragePlatform.instance` globally and never restores it,
  which silently disables any later channel mock in the same file — the new
  `test/support/fakes/secure_storage_channel.dart` exists to avoid that trap.)
- On device the failure path cannot be reproduced honestly — it needs a broken
  Android Keystore. What was checked is that the happy path did not regress:
  `12-audio-settings.png` shows the page rendering content instead of a spinner,
  and the Settings > Playback toggles are interactive, which is exactly the
  `isLoading == false` signal.

## Checks

- `flutter analyze` — no issues (lib + test).
- `flutter test test/ui test/data/sources test/providers` — 587 passed.
- `flutter test test/support` — 20 passed (the AGENTS.md doc rules).
- `dart format --output=none --set-exit-if-changed lib test` — clean.
- `lib/ui/AGENTS.md` gains the scrolling-rail rule and qualifies the
  "never remove content" rule for row-level secondary decoration;
  `lib/data/sources/AGENTS.md` records the NetEase login-vs-VIP ordering.

## Windows desktop check

Reaching 411dp on Windows needed a fixture. `AppConstants.minimumWindowHeight` is
500dp by design, and external resizing turned out to be blocked outright: both
`SetWindowPos` and a bottom-edge mouse drag were clamped to 3586 physical px
(~2390dp) by the window's own `WM_GETMINMAXINFO`, regardless of what
`WindowOptions.minimumSize` holds. So I temporarily set `defaultWindowWidth` /
`defaultWindowHeight` to 950/411 and `minimumWindowHeight` to 300 in an
**uncommitted local edit**, relaunched `flutter run -d windows`, and reverted
afterwards — the manipulated thing is the window size, not the layout under test.
`GetWindowRect` then measured **1425x616 physical at 144 dpi = exactly 950x411 dp**.

At that size:

- The collapsed rail shows the pinned menu button and 首頁 / 搜尋 / 佇列 / 音樂庫 /
  電台, with **no overflow stripe** at the bottom.
- Two mouse-wheel scrolls over the rail bring **設定** fully into view; the menu
  button stays exactly where it was.
- Clicking 設定 navigates to the Settings page.
- The two ranking columns in the content area are above the narrow threshold and
  render normally (play counts `94.2萬`, `1.5億` present, no overflow).

Two environment notes for whoever runs this next, neither an FMP defect:

- Incremental Windows builds in a `.claude/worktrees/...` path fail with MSBuild
  `MSB3501` on `flutter_inappwebview_windows`'s `.tlog` — the path is close enough
  to `MAX_PATH` that the state file cannot be re-read. Deleting
  `build/windows/x64/plugins/flutter_inappwebview_windows` makes the next build
  succeed, once.
- `orca computer get-app-state --restore-window` did **not** raise the FMP window
  above another app, and neither did `SetForegroundWindow` / `HWND_TOPMOST`; every
  capture came back as the window that was on top. Minimising the occluding window
  was the only thing that worked.

Closes #84, closes #85, closes #87, closes #89
