### PR TITLE
refactor(sources): drop the dead capability surface

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -27,10 +27,8 @@ _Avoid_: media auth, playback headers
 
 **Auth For Play**:
 The user setting that gates credentials for stream resolution, playback handoff,
-download, track detail, and auth-aware metadata/detail service paths. Existing
-`SourceManager.parseUrl()` / `refreshAudioUrl()` capability helpers remain
-unauthenticated unless a future auth-aware overload is added. Auth For Play does
-not control playlist import, playlist refresh, or search.
+download, track detail, and auth-aware metadata/detail service paths. Auth
+For Play does not control playlist import, playlist refresh, or search.
 _Avoid_: import auth, search auth
 
 **Media Request Credentials**:

--- a/lib/data/sources/AGENTS.md
+++ b/lib/data/sources/AGENTS.md
@@ -162,10 +162,8 @@ services or UI.**
 
 `authForPlay()` covers stream resolution, playback handoff, download stream
 resolution, download metadata detail, track detail, and auth-aware metadata
-paths. `SourceManager.parseUrl()` / `refreshAudioUrl()` stay unauthenticated
-unless a future auth-aware overload is added. Search requests no auth; playlist
-import uses the import entry choice, playlist refresh uses
-`Playlist.useAuthForRefresh`.
+paths. Search requests no auth; playlist import uses the import entry
+choice, playlist refresh uses `Playlist.useAuthForRefresh`.
 
 `SourceHttpPolicy` centralizes API/media header defaults — adapters and account
 services create Dio clients through `createApiDio()` and use `apiHeaders()`.

--- a/lib/data/sources/bilibili_source.dart
+++ b/lib/data/sources/bilibili_source.dart
@@ -45,7 +45,6 @@ class BilibiliSource
         AudioStreamSource,
         SearchSource,
         PlaylistParsingSource,
-        AvailabilitySource,
         TrackDetailSource,
         PagedVideoSource,
         RankingSource,
@@ -727,19 +726,6 @@ class BilibiliSource
       if (e is BilibiliApiException) rethrow;
       logError('Unexpected error in parsePlaylist: $e');
       throw BilibiliApiException(numericCode: -999, message: e.toString());
-    }
-  }
-
-  @override
-  Future<bool> checkAvailability(String sourceId) async {
-    try {
-      final response = await _dio.get(
-        _viewApi,
-        queryParameters: {'bvid': sourceId},
-      );
-      return response.data['code'] == 0;
-    } catch (_) {
-      return false;
     }
   }
 

--- a/lib/data/sources/bilibili_source.dart
+++ b/lib/data/sources/bilibili_source.dart
@@ -189,11 +189,6 @@ class BilibiliSource
   }
 
   @override
-  bool isValidId(String id) {
-    return RegExp(r'^BV[a-zA-Z0-9]{10}$').hasMatch(id);
-  }
-
-  @override
   bool canHandle(String url) => parseId(url) != null;
 
   @override
@@ -206,50 +201,6 @@ class BilibiliSource
         url.contains('/fav/') ||
         RegExp(r'fid=\d+').hasMatch(url) ||
         RegExp(r'ml\d+').hasMatch(url);
-  }
-
-  @override
-  Future<Track> getTrackInfo(
-    String bvid, {
-    Map<String, String>? authHeaders,
-  }) async {
-    try {
-      final response = await _dio.get(
-        _viewApi,
-        queryParameters: {'bvid': bvid},
-        options: authHeaders != null ? _withAuth(authHeaders) : null,
-      );
-
-      _checkResponse(response.data);
-
-      final data = response.data['data'];
-      final track = Track()
-        ..sourceId = bvid
-        ..sourceType = SourceIds.bilibili
-        ..title = data['title'] ?? 'Unknown'
-        ..artist = data['owner']?['name']
-        ..ownerId = data['owner']?['mid'] as int?
-        ..durationMs = ((data['duration'] as int?) ?? 0) * 1000
-        ..thumbnailUrl = data['pic'];
-
-      // 获取音频 URL
-      final audioUrl = await getAudioUrl(
-        AudioStreamRequest(sourceId: bvid, authHeaders: authHeaders),
-      );
-      track.audioUrl = audioUrl;
-      track.audioUrlExpiry = DateTime.now().add(
-        const Duration(hours: AppConstants.bilibiliAudioUrlExpiryHours),
-      );
-      track.createdAt = DateTime.now();
-
-      return track;
-    } on DioException catch (e) {
-      throw _handleDioError(e);
-    } catch (e) {
-      if (e is BilibiliApiException) rethrow;
-      logError('Unexpected error in getTrackInfo: $e');
-      throw BilibiliApiException(numericCode: -999, message: e.toString());
-    }
   }
 
   @override
@@ -527,34 +478,6 @@ class BilibiliSource
       case AudioQualityLevel.low:
         return sortedItems.last;
     }
-  }
-
-  @override
-  Future<Track> refreshAudioUrl(
-    Track track, {
-    Map<String, String>? authHeaders,
-  }) async {
-    if (track.sourceType != SourceIds.bilibili) {
-      throw const BilibiliApiException(
-        numericCode: -3,
-        message: 'Invalid source type for BilibiliSource',
-      );
-    }
-
-    final audioUrl = await getAudioUrl(
-      AudioStreamRequest(
-        sourceId: track.sourceId,
-        cid: track.cid,
-        pageNum: track.pageNum,
-        authHeaders: authHeaders,
-      ),
-    );
-    track.audioUrl = audioUrl;
-    track.audioUrlExpiry = DateTime.now().add(
-      const Duration(hours: AppConstants.bilibiliAudioUrlExpiryHours),
-    );
-    track.updatedAt = DateTime.now();
-    return track;
   }
 
   @override

--- a/lib/data/sources/netease_source.dart
+++ b/lib/data/sources/netease_source.dart
@@ -30,7 +30,6 @@ class NeteaseSource
         AudioStreamSource,
         SearchSource,
         PlaylistParsingSource,
-        AvailabilitySource,
         TrackDetailSource,
         RankingSource {
   late final Dio _dio;
@@ -426,18 +425,6 @@ class NeteaseSource
     );
     track.updatedAt = DateTime.now();
     return track;
-  }
-
-  @override
-  Future<bool> checkAvailability(String sourceId) async {
-    try {
-      final songData = await _getSongDetail(sourceId);
-      final privilege = songData['privilege'] as Map<String, dynamic>?;
-      final st = privilege?['st'] as int?;
-      return st != -200;
-    } catch (_) {
-      return false;
-    }
   }
 
   @override

--- a/lib/data/sources/netease_source.dart
+++ b/lib/data/sources/netease_source.dart
@@ -63,7 +63,6 @@ class NeteaseSource
     return _parseSongIdFromUri(uri);
   }
 
-  @override
   bool isValidId(String id) => RegExp(r'^\d+$').hasMatch(id);
 
   @override
@@ -86,42 +85,6 @@ class NeteaseSource
   @override
   bool canHandle(String url) {
     return parseId(url) != null;
-  }
-
-  // ========== 歌曲信息 ==========
-
-  @override
-  Future<Track> getTrackInfo(
-    String sourceId, {
-    Map<String, String>? authHeaders,
-  }) async {
-    try {
-      final songData = await _getSongDetail(sourceId, authHeaders: authHeaders);
-      final song = songData['song'] as Map<String, dynamic>;
-      final privilege = songData['privilege'] as Map<String, dynamic>?;
-
-      final track = _parseSongToTrack(song, privilege);
-
-      try {
-        final audioUrl = await getAudioUrl(
-          AudioStreamRequest(sourceId: sourceId, authHeaders: authHeaders),
-        );
-        track.audioUrl = audioUrl;
-        // 這條路只拿得到 URL 字串，沒有 expi，只能用退路值。
-        track.audioUrlExpiry = DateTime.now().add(_fallbackAudioUrlExpiry);
-      } catch (_) {
-        // 音頻 URL 獲取失敗不影響歌曲信息
-      }
-
-      track.createdAt = DateTime.now();
-      return track;
-    } on DioException catch (e) {
-      throw _handleDioError(e);
-    } catch (e) {
-      if (e is NeteaseApiException) rethrow;
-      logError('Unexpected error in getTrackInfo: $e');
-      throw NeteaseApiException(numericCode: -999, message: e.toString());
-    }
   }
 
   // ========== 音頻流（eapi 加密） ==========
@@ -399,33 +362,6 @@ class NeteaseSource
 
   @override
   String get rankingLabel => 'Netease 熱歌榜';
-
-  // ========== 刷新 / 可用性 ==========
-
-  @override
-  Future<Track> refreshAudioUrl(
-    Track track, {
-    Map<String, String>? authHeaders,
-  }) async {
-    if (track.sourceType != SourceIds.netease) {
-      throw const NeteaseApiException(
-        numericCode: -3,
-        message: 'Invalid source type for NeteaseSource',
-      );
-    }
-
-    final result = await getAudioStream(
-      AudioStreamRequest(sourceId: track.sourceId, authHeaders: authHeaders),
-    );
-    track.audioUrl = result.url;
-    // 跟 AudioStreamResult 回報的 TTL 一致 —— 兩邊各算各的，就會出現
-    // 「解析說還有 20 分鐘、track 說只剩 16 分鐘」這種對不上的狀態。
-    track.audioUrlExpiry = DateTime.now().add(
-      result.expiry ?? _fallbackAudioUrlExpiry,
-    );
-    track.updatedAt = DateTime.now();
-    return track;
-  }
 
   @override
   void dispose() {

--- a/lib/data/sources/source_capabilities.dart
+++ b/lib/data/sources/source_capabilities.dart
@@ -130,7 +130,3 @@ abstract interface class PlaylistParsingSource implements SourceCapability {
     Map<String, String>? authHeaders,
   });
 }
-
-abstract interface class AvailabilitySource implements SourceCapability {
-  Future<bool> checkAvailability(String sourceId);
-}

--- a/lib/data/sources/source_capabilities.dart
+++ b/lib/data/sources/source_capabilities.dart
@@ -18,18 +18,7 @@ abstract interface class DisposableSource {
 
 abstract interface class TrackInfoSource implements SourceCapability {
   String? parseId(String url);
-  bool isValidId(String id);
   bool canHandle(String url);
-
-  Future<Track> getTrackInfo(
-    String sourceId, {
-    Map<String, String>? authHeaders,
-  });
-
-  Future<Track> refreshAudioUrl(
-    Track track, {
-    Map<String, String>? authHeaders,
-  });
 }
 
 abstract interface class AudioStreamSource implements SourceCapability {
@@ -38,18 +27,6 @@ abstract interface class AudioStreamSource implements SourceCapability {
   Future<AudioStreamResult?> getAlternativeAudioStream(
     AudioStreamRequest request,
   );
-}
-
-extension AudioStreamSourceConvenience on AudioStreamSource {
-  Future<String> getAudioUrl(AudioStreamRequest request) async {
-    final result = await getAudioStream(request);
-    return result.url;
-  }
-
-  Future<String?> getAlternativeAudioUrl(AudioStreamRequest request) async {
-    final result = await getAlternativeAudioStream(request);
-    return result?.url;
-  }
 }
 
 abstract interface class TrackDetailSource implements SourceCapability {

--- a/lib/data/sources/source_provider.dart
+++ b/lib/data/sources/source_provider.dart
@@ -1,7 +1,6 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:fmp/core/logger.dart';
-import 'package:fmp/data/models/track.dart';
 import 'package:fmp/data/sources/base_source.dart';
 import 'package:fmp/data/sources/bilibili_source.dart';
 import 'package:fmp/data/sources/netease_source.dart';
@@ -17,9 +16,6 @@ class SourceManager with Logging {
       );
 
   final List<SourceCapability> _sources;
-
-  /// 所有已注册能力对象。调用端应优先使用下方 narrow lookup。
-  List<SourceCapability> get sources => List.unmodifiable(_sources);
 
   /// 已注册的音源类型列表
   List<String> get registeredSourceTypes {
@@ -87,43 +83,6 @@ class SourceManager with Logging {
   String? sourceTypeForUrl(String url) {
     return playlistParsingSourceForUrl(url)?.sourceType ??
         trackInfoSourceForUrl(url)?.sourceType;
-  }
-
-  /// 解析 URL 获取歌曲信息
-  Future<Track?> parseUrl(String url) async {
-    final source = trackInfoSourceForUrl(url);
-    if (source == null) return null;
-
-    final id = source.parseId(url);
-    if (id == null) return null;
-
-    return source.getTrackInfo(id);
-  }
-
-  /// 判断 URL 是否是播放列表
-  bool isPlaylistUrl(String url) {
-    return playlistParsingSourceForUrl(url) != null;
-  }
-
-  /// 解析播放列表
-  Future<PlaylistParseResult?> parsePlaylist(
-    String url, {
-    int page = 1,
-    int pageSize = 20,
-  }) async {
-    final source = playlistParsingSourceForUrl(url);
-    if (source == null) return null;
-    return source.parsePlaylist(url, page: page, pageSize: pageSize);
-  }
-
-  /// 刷新歌曲的音频 URL
-  Future<Track> refreshAudioUrl(Track track) async {
-    final source = trackInfoSource(track.sourceType);
-    if (source == null) {
-      throw Exception('Source not found for ${track.sourceType}');
-    }
-
-    return source.refreshAudioUrl(track);
   }
 
   /// 搜索

--- a/lib/data/sources/source_provider.dart
+++ b/lib/data/sources/source_provider.dart
@@ -50,9 +50,6 @@ class SourceManager with Logging {
   PlaylistParsingSource? playlistParsingSource(String type) =>
       _capability<PlaylistParsingSource>(type);
 
-  AvailabilitySource? availabilitySource(String type) =>
-      _capability<AvailabilitySource>(type);
-
   TrackDetailSource? trackDetailSource(String type) =>
       _capability<TrackDetailSource>(type);
 

--- a/lib/data/sources/youtube_source.dart
+++ b/lib/data/sources/youtube_source.dart
@@ -172,7 +172,6 @@ class YouTubeSource
     }
   }
 
-  @override
   bool isValidId(String id) {
     // YouTube video ID 是 11 个字符
     return RegExp(r'^[a-zA-Z0-9_-]{11}$').hasMatch(id);
@@ -202,69 +201,6 @@ class YouTubeSource
       return yt.PlaylistId.parsePlaylistId(url);
     } catch (_) {
       return null;
-    }
-  }
-
-  @override
-  Future<Track> getTrackInfo(
-    String videoId, {
-    Map<String, String>? authHeaders,
-  }) async {
-    // If auth headers provided, use InnerTube API path
-    if (authHeaders != null) {
-      return _getTrackInfoViaInnerTube(videoId, authHeaders);
-    }
-
-    logDebug('Getting track info for YouTube video: $videoId');
-    try {
-      final video = await _youtube.videos.get(videoId);
-
-      final track = Track()
-        ..sourceId = videoId
-        ..sourceType = SourceIds.youtube
-        ..title = video.title
-        ..artist = video.author
-        ..channelId = video.channelId.value
-        ..durationMs = video.duration?.inMilliseconds ?? 0
-        // Store hqdefault as the canonical key instead of highResUrl
-        // (maxresdefault). If the stored URL is already the highest tier,
-        // ThumbnailUrlUtils cannot build a useful candidate chain.
-        // Display loading still tries only 16:9 candidates
-        // (maxresdefault/mqdefault) to avoid black bars.
-        ..thumbnailUrl = 'https://i.ytimg.com/vi/$videoId/hqdefault.jpg'
-        ..viewCount = video.engagement.viewCount;
-
-      // 获取音频 URL
-      final audioUrl = await getAudioUrl(AudioStreamRequest(sourceId: videoId));
-      track.audioUrl = audioUrl;
-      // YouTube URL 过期较快，使用 1 小时有效期
-      track.audioUrlExpiry = DateTime.now().add(
-        const Duration(hours: AppConstants.youtubeAudioUrlExpiryHours),
-      );
-      track.createdAt = DateTime.now();
-
-      logDebug('Got track info for $videoId: ${video.title}');
-      return track;
-    } on yt.VideoUnplayableException catch (e) {
-      logError('YouTube video unplayable: $videoId, reason: $e');
-      throw YouTubeApiException(
-        code: 'unplayable',
-        message: 'Video is unplayable: $e',
-      );
-    } catch (e) {
-      if (e is YouTubeApiException) rethrow;
-      if (_isRateLimitError(e)) {
-        logWarning('YouTube rate limited for video: $videoId');
-        throw YouTubeApiException(
-          code: 'rate_limited',
-          message: t.error.rateLimited,
-        );
-      }
-      logError('Failed to get YouTube video info: $videoId, error: $e');
-      throw YouTubeApiException(
-        code: 'error',
-        message: 'Failed to get video info: $e',
-      );
     }
   }
 
@@ -918,29 +854,6 @@ class YouTubeSource
       }
     }
     return null;
-  }
-
-  @override
-  Future<Track> refreshAudioUrl(
-    Track track, {
-    Map<String, String>? authHeaders,
-  }) async {
-    if (track.sourceType != SourceIds.youtube) {
-      throw const YouTubeApiException(
-        code: 'invalid_source',
-        message: 'Invalid source type for YouTubeSource',
-      );
-    }
-
-    final audioUrl = await getAudioUrl(
-      AudioStreamRequest(sourceId: track.sourceId, authHeaders: authHeaders),
-    );
-    track.audioUrl = audioUrl;
-    track.audioUrlExpiry = DateTime.now().add(
-      const Duration(hours: AppConstants.youtubeAudioUrlExpiryHours),
-    );
-    track.updatedAt = DateTime.now();
-    return track;
   }
 
   /// 将 SearchOrder 转换为 YouTube 搜索过滤器
@@ -2350,54 +2263,6 @@ class YouTubeSource
   }
 
   // ==================== 错误处理 ====================
-
-  /// 通过 InnerTube /player API 获取视频信息（认证路径）
-  Future<Track> _getTrackInfoViaInnerTube(
-    String videoId,
-    Map<String, String> authHeaders,
-  ) async {
-    logDebug('Getting track info via InnerTube for: $videoId');
-    try {
-      final data = await _innerTubePlayerRequest(videoId, authHeaders);
-
-      final videoDetails = data['videoDetails'] as Map<String, dynamic>?;
-      if (videoDetails == null) {
-        throw const YouTubeApiException(
-          code: 'parse_error',
-          message: 'No videoDetails in response',
-        );
-      }
-
-      final lengthSeconds =
-          int.tryParse(videoDetails['lengthSeconds']?.toString() ?? '0') ?? 0;
-      final viewCount =
-          int.tryParse(videoDetails['viewCount']?.toString() ?? '0') ?? 0;
-      final thumbnailUrl = 'https://i.ytimg.com/vi/$videoId/hqdefault.jpg';
-
-      final track = Track()
-        ..sourceId = videoId
-        ..sourceType = SourceIds.youtube
-        ..title = videoDetails['title'] as String? ?? 'Unknown'
-        ..artist = videoDetails['author'] as String? ?? ''
-        ..channelId = videoDetails['channelId'] as String? ?? ''
-        ..durationMs = lengthSeconds * 1000
-        ..thumbnailUrl = thumbnailUrl
-        ..viewCount = viewCount
-        ..createdAt = DateTime.now();
-
-      logDebug('Got track info via InnerTube for $videoId: ${track.title}');
-      return track;
-    } on DioException catch (e) {
-      throw _handleDioError(e);
-    } catch (e) {
-      if (e is YouTubeApiException) rethrow;
-      logError('Failed to get track info via InnerTube: $videoId, error: $e');
-      throw YouTubeApiException(
-        code: 'error',
-        message: 'Failed to get video info: $e',
-      );
-    }
-  }
 
   /// 通过 InnerTube /player API 获取视频详情（认证路径）
   Future<VideoDetail> _getVideoDetailViaInnerTube(

--- a/lib/data/sources/youtube_source.dart
+++ b/lib/data/sources/youtube_source.dart
@@ -30,7 +30,6 @@ class YouTubeSource
         AudioStreamSource,
         SearchSource,
         PlaylistParsingSource,
-        AvailabilitySource,
         TrackDetailSource,
         DynamicPlaylistSource,
         RankingSource {
@@ -1669,16 +1668,6 @@ class YouTubeSource
         'Failed to get owner ID via InnerTube for playlist: $playlistId, error: $e',
       );
       return null;
-    }
-  }
-
-  @override
-  Future<bool> checkAvailability(String sourceId) async {
-    try {
-      await _youtube.videos.get(sourceId);
-      return true;
-    } catch (_) {
-      return false;
     }
   }
 

--- a/lib/services/audio/media_kit_audio_service.dart
+++ b/lib/services/audio/media_kit_audio_service.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:io';
 
 import 'package:audio_session/audio_session.dart' hide AudioDevice;
 import 'package:media_kit/media_kit.dart' hide Track;
@@ -17,8 +16,6 @@ import 'package:fmp/services/audio/playback_media.dart';
 /// 解决了 just_audio_media_kit 代理对 audio-only 流的兼容性问题
 /// 用于 Windows/Linux 平台
 class MediaKitAudioService extends FmpAudioService with Logging {
-  static const int mobilePlayerBufferSizeBytes = 2 * 1024 * 1024;
-
   /// 桌面端緩衝：設為極大值以一次性下載整首歌曲
   /// 避免分段下載時 TCP 連線閒置被 YouTube CDN 切斷（WSAECONNRESET）
   /// 一首 5 分鐘 320kbps 的歌約 12MB，桌面端完全負擔得起
@@ -95,7 +92,6 @@ class MediaKitAudioService extends FmpAudioService with Logging {
   );
   final _speedController = BehaviorSubject<double>.seeded(1.0);
   final _playingController = BehaviorSubject<bool>.seeded(false);
-  final _volumeController = BehaviorSubject<double>.seeded(1.0);
 
   // 音频设备相关
   final _audioDevicesController = BehaviorSubject<List<FmpAudioDevice>>.seeded(
@@ -171,11 +167,10 @@ class MediaKitAudioService extends FmpAudioService with Logging {
 
     // 创建 media_kit 播放器
     // 桌面端保留更大的网络缓冲，吸收 VPN 切换或 CDN 抖动造成的短时中断。
-    final bufferSize = (Platform.isAndroid || Platform.isIOS)
-        ? mobilePlayerBufferSizeBytes
-        : desktopPlayerBufferSizeBytes;
     _player = Player(
-      configuration: PlayerConfiguration(bufferSize: bufferSize),
+      configuration: const PlayerConfiguration(
+        bufferSize: desktopPlayerBufferSizeBytes,
+      ),
     );
     _hasPlayer = true;
 
@@ -432,7 +427,6 @@ class MediaKitAudioService extends FmpAudioService with Logging {
       _player.stream.volume.listen((vol) {
         // media_kit 音量范围是 0-100，转换为 0-1
         _volume = vol / 100.0;
-        _volumeController.add(_volume);
       }),
     );
 
@@ -619,7 +613,6 @@ class MediaKitAudioService extends FmpAudioService with Logging {
     await _bufferedPositionController.close();
     await _speedController.close();
     await _playingController.close();
-    await _volumeController.close();
     await _audioDevicesController.close();
     await _audioDeviceController.close();
 

--- a/test/bilibili_source_test.dart
+++ b/test/bilibili_source_test.dart
@@ -12,7 +12,6 @@ import 'package:fmp/data/sources/bilibili_source.dart';
 import 'package:fmp/data/sources/bilibili_exception.dart';
 import 'package:fmp/data/sources/bilibili_live_client.dart';
 import 'package:fmp/data/models/track.dart';
-import 'package:fmp/data/sources/source_capabilities.dart';
 import 'package:fmp/data/sources/source_exception.dart';
 
 void main() {
@@ -197,7 +196,7 @@ void main() {
       );
     });
 
-    group('getAudioUrl', () {
+    group('getAudioStream', () {
       test('preserves rate-limit errors during stream fallback', () async {
         final dio = Dio();
         dio.httpClientAdapter = _FakeHttpClientAdapter((options, _) {
@@ -836,9 +835,9 @@ void main() {
         const testBvid = 'BV1xx411c79H'; // 实际存在的视频
 
         try {
-          final audioUrl = await source.getAudioUrl(
+          final audioUrl = (await source.getAudioStream(
             const AudioStreamRequest(sourceId: testBvid),
-          );
+          )).url;
 
           expect(audioUrl, isNotNull);
           expect(audioUrl, isNotEmpty);
@@ -884,130 +883,12 @@ void main() {
         // await expectLater，不是 expect：非同步的 rejection 若沒有 await，會在
         // 這條測試結束之後才浮出來，失敗被算到下一條頭上。
         await expectLater(
-          source.getAudioUrl(
+          source.getAudioStream(
             const AudioStreamRequest(sourceId: 'BV1234567890'),
           ),
           throwsA(isA<BilibiliApiException>()),
         );
       });
-    });
-
-    group('getTrackInfo', () {
-      test('passes auth headers into best-effort audio URL fetch', () async {
-        final requestHeaders = <Map<String, dynamic>>[];
-        final dio = Dio();
-        dio.httpClientAdapter = _FakeHttpClientAdapter((options, _) {
-          requestHeaders.add(Map<String, dynamic>.from(options.headers));
-
-          if (options.path.endsWith('/x/web-interface/view')) {
-            return ResponseBody.fromString(
-              jsonEncode({
-                'code': 0,
-                'data': {
-                  'cid': 12345,
-                  'title': 'Auth Track',
-                  'owner': {'name': 'Auth Owner', 'mid': 1001},
-                  'duration': 60,
-                  'pic': 'https://example.com/cover.jpg',
-                },
-              }),
-              200,
-              headers: {
-                Headers.contentTypeHeader: ['application/json'],
-              },
-            );
-          }
-
-          if (options.path.endsWith('/x/player/playurl')) {
-            return ResponseBody.fromString(
-              jsonEncode({
-                'code': 0,
-                'data': {
-                  'dash': {
-                    'audio': [
-                      {
-                        'baseUrl': 'https://example.com/auth-audio.m4s',
-                        'bandwidth': 192000,
-                      },
-                    ],
-                  },
-                },
-              }),
-              200,
-              headers: {
-                Headers.contentTypeHeader: ['application/json'],
-              },
-            );
-          }
-
-          throw StateError('Unexpected request: ${options.path}');
-        });
-        final source = BilibiliSource(
-          dio: dio,
-          apiBase: 'https://api.bilibili.test',
-        );
-
-        final track = await source.getTrackInfo(
-          'BVauth',
-          authHeaders: const {'Cookie': 'SESSDATA=auth'},
-        );
-
-        expect(track.audioUrl, 'https://example.com/auth-audio.m4s');
-        expect(requestHeaders, hasLength(3));
-        expect(
-          requestHeaders.every(
-            (headers) =>
-                (headers['Cookie'] as String?)?.contains('SESSDATA=auth') ==
-                true,
-          ),
-          isTrue,
-        );
-      });
-    });
-
-    group('refreshAudioUrl', () {
-      test('should refresh audio URL for track with expired URL', () async {
-        // 创建一个带有过期URL的track
-        const originalUrl = 'https://expired-url.com/audio.m4s';
-        final track = Track()
-          ..sourceId = 'BV1xx411c79H'
-          ..sourceType = SourceIds.bilibili
-          ..title = 'Test Track'
-          ..audioUrl = originalUrl
-          ..audioUrlExpiry = DateTime.now().subtract(const Duration(hours: 1));
-
-        // URL 应该已经过期
-        expect(track.hasValidAudioUrl, isFalse);
-
-        try {
-          final refreshedTrack = await source.refreshAudioUrl(track);
-
-          expect(refreshedTrack.audioUrl, isNotNull);
-          // 新URL应该与原来的假URL不同
-          expect(refreshedTrack.audioUrl, isNot(equals(originalUrl)));
-          // 新URL应该是有效的HTTP URL
-          expect(refreshedTrack.audioUrl, contains('http'));
-          expect(refreshedTrack.hasValidAudioUrl, isTrue);
-          expect(refreshedTrack.audioUrlExpiry, isNotNull);
-          expect(
-            refreshedTrack.audioUrlExpiry!.isAfter(DateTime.now()),
-            isTrue,
-          );
-          debugPrint('Successfully refreshed audio URL');
-        } on BilibiliApiException catch (e) {
-          if (e.isUnavailable || e.numericCode == -404) {
-            debugPrint(
-              'Video unavailable (code: ${e.numericCode}), skipping test: ${e.message}',
-            );
-            return;
-          }
-          rethrow;
-        } on DioException catch (e) {
-          debugPrint('Network error, skipping test: ${e.message}');
-          return;
-        }
-        // 同上：打真实网络，B 站风控时会失败，不该拦住无关的 PR。
-      }, tags: 'live');
     });
 
     group('URL expiry', () {

--- a/test/data/sources/source_capabilities_test.dart
+++ b/test/data/sources/source_capabilities_test.dart
@@ -29,11 +29,6 @@ void main() {
         isA<PlaylistParsingSource>(),
         reason: '$sourceType should parse internal playlists',
       );
-      expect(
-        manager.availabilitySource(sourceType),
-        isA<AvailabilitySource>(),
-        reason: '$sourceType should check availability',
-      );
     }
   });
 

--- a/test/providers/refresh_provider_stale_cleanup_test.dart
+++ b/test/providers/refresh_provider_stale_cleanup_test.dart
@@ -309,9 +309,6 @@ class _ControllableRefreshSource extends BilibiliSource {
   bool isValidId(String id) => true;
 
   @override
-  Future<bool> checkAvailability(String sourceId) async => true;
-
-  @override
   Future<AudioStreamResult> getAudioStream(AudioStreamRequest request) async {
     return AudioStreamResult(
       url: 'https://example.com/${request.sourceId}.m4a',

--- a/test/providers/refresh_provider_stale_cleanup_test.dart
+++ b/test/providers/refresh_provider_stale_cleanup_test.dart
@@ -306,23 +306,11 @@ class _ControllableRefreshSource extends BilibiliSource {
   String? parseId(String url) => url;
 
   @override
-  bool isValidId(String id) => true;
-
-  @override
   Future<AudioStreamResult> getAudioStream(AudioStreamRequest request) async {
     return AudioStreamResult(
       url: 'https://example.com/${request.sourceId}.m4a',
       streamType: StreamType.audioOnly,
     );
-  }
-
-  @override
-  Future<Track> getTrackInfo(
-    String sourceId, {
-    Map<String, String>? authHeaders,
-  }) async {
-    onTrackInfo?.call();
-    return _track(sourceId);
   }
 
   @override
@@ -335,14 +323,6 @@ class _ControllableRefreshSource extends BilibiliSource {
       VideoPage(cid: 101, page: 1, part: 'Part One', duration: 180),
       VideoPage(cid: 102, page: 2, part: 'Part Two', duration: 181),
     ];
-  }
-
-  @override
-  Future<Track> refreshAudioUrl(
-    Track track, {
-    Map<String, String>? authHeaders,
-  }) async {
-    return track;
   }
 
   @override


### PR DESCRIPTION
M4 step 4.1 of the post-audit plan: delete the source-layer capability surface
that has no production consumer, plus the two dead branches in the media_kit
backend. Four commits, one topic each, every one of them green on its own.

Step 4.2 (`NeteasePlaylistSource`) is **not** in this PR. The audit's premise was
confirmed but turned out to be incomplete; see the last section.

**Net: -554 lines, +11.**

## What was deleted, and how each was re-verified

Every item was re-checked with `rg` over `lib/` and `test/` before deletion --
"only a test calls it" counts as dead.

### 1. `AvailabilitySource` (`cd3aa568`, -53)

Interface, `SourceManager.availabilitySource()`, three adapter implementations,
one capability assertion, one test fake. **Zero production consumers.**

```
rg -n "AvailabilitySource|checkAvailability" lib test
```
returned only the interface declaration, the three `checkAvailability` bodies,
the accessor, `source_capabilities_test.dart:32-36` and one fake override.

The assertion in `source_capabilities_test.dart` was guarding an interface
nothing called, which is worse than having no test: it made the surface read as
load-bearing.

### 2. The zero-caller `SourceManager` facade (`19f721c7`, -45)

`parseUrl`, `isPlaylistUrl`, `parsePlaylist`, `refreshAudioUrl` and the `sources`
getter. Verified per member:

| member | every `rg` hit |
|---|---|
| `parseUrl` | `RadioSource.parseUrl` (a different class) + its own tests |
| `isPlaylistUrl` | the `PlaylistParsingSource` capability, never the facade |
| `parsePlaylist` | `import_service.dart:198/445` call `source.parsePlaylist`, i.e. the capability |
| `refreshAudioUrl` | the three adapter implementations only |
| `sources` | `plan.sources` in the home page, and one string literal inside the ownership static rule |

Runtime callers already go through the narrow capability accessors -- that is
what `source_ownership_static_rule_test.dart` enforces. The facade was a second,
broader way in that nothing used. `searchAll` / `searchFrom` are **not** touched:
they have live callers and belong to step 4.5.

`lib/data/sources/AGENTS.md` no longer names the two deleted entry points in its
auth paragraph.

### 3. The dead `TrackInfoSource` methods (`cde4769e`, -446)

`isValidId`, `getTrackInfo` and `refreshAudioUrl` had exactly one caller each:
the facade deleted in the previous commit. Removing the three implementations
also orphaned two more things, both deleted in the same commit:

- `YouTubeSource._getTrackInfoViaInnerTube` (the authenticated track-info path),
  reachable only from `getTrackInfo`;
- the `AudioStreamSourceConvenience` extension -- `getAudioUrl` was called only
  from inside the deleted methods, `getAlternativeAudioUrl` from nowhere at all.

Kept: `parseId` and `canHandle`. `sourceTypeForUrl` still routes the import
dialog through them. `isValidId` survives as a plain method on the YouTube and
Netease adapters, which call it from their own `parseId`.

Tests: the `getTrackInfo` and `refreshAudioUrl` groups in
`test/bilibili_source_test.dart` went with the methods; the two `getAudioUrl`
call sites became `getAudioStream(...).url`, which is what the extension did.

`CONTEXT.md` no longer describes the deleted helpers as an Auth-For-Play
exception.

### 4. media_kit dead branches (`0d56c794`, -10)

- **B13** -- the buffer profile branched on `Platform.isAndroid ||
  Platform.isIOS`, but `audio_controller_provider.dart:28-29` hands mobile a
  `JustAudioService`, so the mobile arm and `mobilePlayerBufferSizeBytes` could
  never run. The size is now the compile-time constant the surviving arm always
  produced. `dart:io` went with it -- `Platform` was its only use in the file.
- **B14** -- `_volumeController` fed a stream nothing subscribed to:
  `FmpAudioService` declares no `volumeStream` and `rg volumeStream lib test`
  is empty. The `_volume` field it mirrored stays; ducking and the `volume`
  getter read it.

`lib/services/audio/AGENTS.md` needed no change -- it never documented either.

## Verification

```
flutter analyze                                     No issues found!
dart format --output=none --set-exit-if-changed lib test tool   587 files (0 changed)
flutter test --exclude-tags live                    +1555: All tests passed!
```

The step's own acceptance, run after each commit:

```
flutter test test/data/sources test/services/audio
```

**Android emulator (`Medium_Phone`, `-no-snapshot-load`), debug build of this
branch.** All three ranking sources loaded on the home page
(`[RankingCache] bilibili: true, youtube: true, netease: true`), so the
capability lookups that survived still resolve. Library -> Import Playlist ->
`https://music.163.com/playlist?id=3778678` imported 200 tracks
(`[PlaylistMutationRepository] Mutated playlist 1: added 200`) with full
Netease metadata; deleted afterwards, emulator torn down with `adb emu kill`.

**Windows desktop build** -- see the checklist comment below for the
`MediaKitAudioService` result.

## Step 4.2 is deferred, with a finding

The plan's step 4.2 says to delete
`lib/data/sources/playlist_import/netease_playlist_source.dart` (259 lines)
once the import dialog is confirmed to route Netease URLs internally.

**The routing premise is confirmed, on device.** `NeteasePlaylistSource.canHandle`
is strictly narrower than `NeteaseSource.isPlaylistUrl`: both parse the same host
allowlist and both accept every short link, but the adapter needs only
`pathSegments.contains('playlist')` while the import source additionally needs
`RemotePlaylistIdParser.parseNeteasePlaylistId` to return non-null. So every URL
the import source accepts is one `sourceTypeForUrl` already claims, and
`_onUrlChanged` returns at its internal branch before the external check runs.
On the emulator the dialog showed the "Import with login credentials" toggle --
rendered only for `_UrlType.internal` -- and the import produced a library
playlist directly instead of the search-matching preview page.

**But the class is not only reachable from there.**
`lib/services/account/netease_playlist_service.dart:73` holds a
`NeteasePlaylistSource` and calls `fetchPlaylist` from `getPlaylistDetail`. The
audit did not have this consumer. `getPlaylistDetail` itself has zero callers in
`lib/` or `test/` and has had none since the commit that introduced it
(`git log -S getPlaylistDetail` -> `1df8878b` only), so the chain **is**
transitively dead -- but deleting it is a different change from the one the plan
describes:

- it takes out a public account-service method, the `NeteasePlaylistDetail`
  class, `_fetchTrackDetails` and `canonicalPlaylistUrl` -- about 115 lines in
  `lib/services/account/`, a subtree the audit did not cover;
- it deletes `test/data/sources/source_url_policy_test.dart:78`, *"short-link
  redirects are not followed to local hosts"*, which is an SSRF regression test
  that happens to use `NeteasePlaylistSource` as its vehicle. The same
  protection lives on the reachable `NeteaseSource._resolveShortUrl` path, so
  that test should be **ported**, not dropped -- and porting a test is not the
  pure deletion this step was scoped as.

So it is left for a decision rather than folded in here. Nothing about it blocks
this PR.
