### PR TITLE
docs: record the v1.10.1 draft and the 4.2 prerequisite in the plan

### DIFF
--- a/docs/plan.md
+++ b/docs/plan.md
@@ -221,9 +221,9 @@ M1 與 M3 互不依賴，可以在兩個 worktree 並行。M4 等 M3 是因為�
 |---|---|---|---|
 | M0 | 完成 2026-09-10 | #94 | `main` 有 `protect-main` ruleset |
 | M1 | 完成 2026-09-10（1.2、1.3 延後） | #96、#101 | 1.2 與 1.3 等 Clash 規則修好、直連下重跑 live 測試再決定（#95）；#85 的標題寬度只到 6 個全形字，再寬要動封面或選單按鈕，超出 issue 範圍 |
-| M2 | 進行中 | 本 PR 升版；tag `v1.10.1` 於合併後打 | 2.3 的五項實機驗證只有你能做，做完各記一行到對應 issue，再 publish draft |
+| M2 | 等你 publish | #103 升版；tag `v1.10.1` 在 `8fbd3517`；draft release 已建，9 個產物、workflow 全綠 | 2.3 的五項實機驗證只有你能做，做完各記一行到對應 issue，再 publish draft |
 | M3 | 進行中 | #97、#98、#99、#100 已合併 | 3.4（#91 README 截圖）與 3.5（兩份超過 200 行的 `AGENTS.md`）未開始；#102 記錄了一條 CI 偶發失敗的音訊測試，歸 M4 步驟 9 判定 |
-| M4 | 未開始 | | |
+| M4 | 進行中 | 4.1 在 #104 | 4.2 不再是純刪除：`NeteasePlaylistSource` 還有 `netease_playlist_service.dart` 的 `getPlaylistDetail` 這條零呼叫鏈在用，連帶約 115 行 account 層程式碼，且 `source_url_policy_test.dart` 的 SSRF 迴歸測試拿它當載體，要先移植到 `NeteaseSource._resolveShortUrl` 再刪。列為 4.2 的前置，下一輪做 |
 | M5 | 未開始 | | |
 
 ---


### PR DESCRIPTION
Progress table only: M2 is waiting on the owner's five on-device checks and the draft publish; M4 step 4.1 is #104; step 4.2 turned out not to be a pure deletion (a second consumer in the account layer and an SSRF regression test that uses the class as its vehicle), so it is recorded as needing a test port first.